### PR TITLE
fix(backup): atomic restore, backup-failure warning, version validation (#14, #15, #16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Backup restore with best-effort rollback** — `restoreFullReplace()` validates all data before deleting existing charts; if writing fails, original data is restored on a best-effort basis (#14)
+- **Clear-all blocks on backup failure** — destructive "Clear All Data" and "Replace" actions now show an explicit warning dialog when the auto-backup fails, requiring user acknowledgment before proceeding (#15)
+- **Version tree validation** — `restoreFullReplace()` and `restoreMerge()` now validate version trees before persisting; malformed versions are skipped with a warning (#16)
+
 ## [3.12.1] — 2026-03-22
 
 ### Fixed
+
 - **Undo stack corruption** — OrgStore mutations (`addChild`, `removeNode`, `updateNode`, `fromJSON`) now validate inputs before creating undo snapshots; failed mutations no longer leave orphan entries
 - **Silent save failures** — `saveVersion()` and `saveWorkingTree()` now catch and report errors to users instead of fire-and-forget
 - **Backup restore accepts invalid trees** — `validateTree()` now runs on backup restore and legacy localStorage migration; invalid trees are skipped or replaced with defaults
@@ -19,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **flatted CVE** — upgraded `flatted` 3.4.1→3.4.2 (prototype pollution, dev-only)
 
 ### Added
+
 - `LoadingOverlay` wired to PPTX/PNG/SVG exports and chart switching — users now see loading feedback during async operations
 - `src/constants/defaults.ts` — single source of truth for renderer default values (previously duplicated in 3 files)
 - `src/utils/debounce.ts` — reusable debounce utility with flush support
@@ -27,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 135 new tests across 10 new test files
 
 ### Changed
+
 - **IndexedDB saves debounced** — `saveWorkingTree()` calls now debounced at 500ms with `beforeunload` flush; eliminates 80% of I/O writes during rapid edits
 - **Rerender batching** — multiple store changes within a single frame now produce one render via `requestAnimationFrame`, down from 5-6 cascading re-renders
 - **OrgStore O(1) lookups** — internal `findNodeById`/`findParent` calls replaced with `Map<string, OrgNode>` index; `moveNode` goes from ~50k node visits to O(1) at 10k nodes
@@ -35,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.12.0] — 2026-03-22
 
 ### Added
+
 - **Dual-track level mappings** — each level can now map to different titles for Managers vs Individual Contributors; auto-detected from tree structure (has children = manager)
 - **Pinned titles** — manually edited titles are auto-pinned and won't be overridden by level mapping; 📌 toggle in property panel to pin/unpin with undo support
 - **Inline editing of level mappings** — click any IC or Manager title cell in the mapping table to edit in-place (Enter saves, Escape cancels)
@@ -50,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 97 new tests across 8 new test files
 
 ### Changed
+
 - `LevelMapping` interface gains optional `managerDisplayTitle` field
 - `OrgNode` interface gains optional `pinnedTitle` boolean field
 - `ChartBundle.chart` gains optional `levelMappings` and `levelDisplayMode` fields
@@ -61,22 +74,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.11.4] — 2026-03-22
 
 ### Fixed
+
 - **Chart list export showing wrong dialog** — the 📤 export button on the active chart in the sidebar was showing the PPTX/SVG/PNG format picker instead of the JSON data export dialog with version selection; created a dedicated `showChartExportDialog()` that correctly exports chart data as `.arbol.json`
 
 ## [3.11.3] — 2026-03-22
 
 ### Fixed
+
 - **CSV import losing level field** — `normalizeTreeText()` was not copying `level` or `dottedLine` when cloning nodes, causing levels mapped during CSV import to be silently dropped when text normalization was applied
 - **Wrong tree shown after deleting active chart** — deleting the active chart left OrgStore holding the deleted chart's tree; the remaining chart now loads correctly
 
 ## [3.11.2] — 2026-03-21
 
 ### Added
+
 - **Analytics disclaimer in help** — added "for reference only" note to the Analytics section in the help dialog
 
 ## [3.11.1] — 2026-03-20
 
 ### Added
+
 - **Analytics Help** — new "Analytics" section in the help dialog explaining all five KPI metrics (Headcount, Org Depth, Manager-to-IC Ratio, Span of Control, Alerts)
 - **KPI Tooltips** — ℹ️ info icons on each analytics KPI card with hover tooltips explaining what each metric measures
 - 16 new i18n keys for analytics help content and tooltips
@@ -84,6 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.11.0] — 2026-03-20
 
 ### Added
+
 - **Advanced Analytics Visualizations** — three new interactive D3 charts in the analytics tab, accessible via sub-tabs:
   - **Zoomable Sunburst** — radial partition chart showing org hierarchy as concentric rings; arc width = team size, color by department category; click-to-zoom with animated transitions, breadcrumb navigation, center label with stats
   - **Span of Control Distribution** — lollipop chart showing manager span distribution with health zone bands (green=healthy 4-8, yellow=watch, red=alert); KPI strip with avg/median/min-max; hover for manager details, click for drill-down list with `onNodeSelect` integration
@@ -93,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Analytics drawer drag-to-resize** — drag the grip bar at the top of the analytics drawer to make it taller or shorter; height persisted in localStorage; constrained between 120px and 80% viewport
 
 ### Performance
+
 - Replace 25 instances of `transition: all` with specific CSS properties (background-color, color, border-color, opacity, transform)
 - Reduce `backdrop-filter: blur(8px)` to `blur(4px)` on 3 modal overlays
 - Move JS hover style mutations to CSS `:hover` rules in settings panels (eliminates per-hover reflows)
@@ -102,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.10.0] — 2026-03-20
 
 ### Added
+
 - **Level Mapping System** — many-to-one mapping from raw level values to display titles (e.g., L10→IC, L12→Senior); three display modes: raw, mapped, or both
 - **LevelStore** — new store for managing level mappings per chart, with CSV import/export support
 - **Level mapping settings** — new "Level Mapping" tab in Settings Modal for managing mappings and display mode
@@ -122,12 +142,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Focus-mode aware analytics** — analytics panel shows metrics for focused subtree when in focus mode
 
 ### Testing
+
 - **2,431 tests across 96 files** — all passing
 - ~152 new tests: analytics metrics (55), level-store (44), analytics-editor (15), level-mapping-panel (15), context-menu level (17), csv-parser level (8), column-mapper level (4), tree-diff level (7), chart-store level integration (6), chart-renderer resolveLevel (3), pptx-exporter resolveLevel (2)
 
 ## [3.9.0] — 2026-03-19
 
 ### Changed
+
 - **Range slider debouncing** — settings sliders now debounce renderer updates at 60ms; value display updates immediately for smooth UX
 - **Chart dirty detection** — `isDirty()` uses mutation counter instead of `JSON.stringify` when available, eliminating repeated serialization of large trees
 - **IndexedDB patchChart** — `saveWorkingTree()` uses new `patchChart()` method, avoiding redundant read-before-write in IndexedDB
@@ -137,12 +159,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Debounce timer cleanup** — settings editor clears pending debounce timers on rebuild and destroy, preventing zombie callbacks
 
 ### Testing
+
 - **2,251 tests across 91 files** — all passing
 - 33 new tests: settings editor debounce (4), chart-store dirty detection (5), patchChart (3), category cache (7), settings cache (4), property panel dropdown (4), context menu caching (6)
 
 ## [3.8.0] — 2026-03-19
 
 ### Added
+
 - **Level metadata** — `level` field on `OrgNode` for organizational level tracking (e.g., L1, L2)
 - **Level badge** — circular indigo badge on org chart cards showing level; configurable color, size, font
 - **Level settings** — show/hide toggle, badge color, text color, font size, badge size in settings panel
@@ -151,11 +175,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PPTX level badge** — ellipse shape in PowerPoint export for circular badge rendering
 
 ### Testing
+
 - **2,218 tests across 90 files** — all passing
 
 ## [3.7.0] — 2026-03-19
 
 ### Added
+
 - **SVG export** — download org chart as `.svg` with proper viewBox, cleaned of ARIA attributes
 - **PNG export** — download org chart as `.png` at configurable resolution (1×, 2×, 3×)
 - **Export format picker** — radio buttons in export dialog to choose PPTX, SVG, or PNG
@@ -164,39 +190,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Respects focus mode — exports only the visible sub-org
 
 ### Fixed
+
 - **PPTX version slides** — selected versions now render as additional PowerPoint slides (was silently dropped)
 
 ### Testing
+
 - **2,147 tests across 89 files** — all passing
 - 27 new tests: SVG/PNG exporter (15), export dialog format picker (6), PPTX version slides (6)
 
 ## [3.6.0] — 2026-03-19
 
 ### Added
+
 - **Spanish locale** — complete Spanish translation (967 keys) in Latin American neutral Spanish
 - **Language switcher** — dropdown in settings modal to switch between English and Español
 - **Locale persistence** — language preference saved in localStorage, restored on app load
 - **Dynamic locale loading** — Spanish bundle loaded on demand via dynamic import (code-split)
 
 ### Testing
+
 - **2,120 tests across 88 files** — all passing
 - 7 new tests: locale persistence, settings UI picker, locale switching
 
 ## [3.5.0] — 2026-03-19
 
 ### Fixed
+
 - **Import shows wrong active chart** — explicitly await sidebar refresh after creating a new chart from import wizard, ensuring the correct chart is displayed as active ([#4](https://github.com/pedrofuentes/arbol/issues/4))
 - **Global error handler** — added `window.onunhandledrejection` handler that shows toast notifications for runtime errors instead of silent console-only failures
 - **localStorage save failures** — settings-store, category-store, and mapping-store now show toast notifications when save operations fail (e.g., storage quota exceeded)
 - **D3 render protection** — wrapped render pipeline and getBBox() calls in try/catch for graceful degradation instead of white-screen crashes
 
 ### Accessibility
+
 - **aria-invalid on form validation** — add-popover, inline-editor, column-mapper, and preset-creator now set `aria-invalid="true"` and `aria-describedby` on inputs when validation fails, and clear them on user input
 
 ### Internationalization
+
 - **29 hardcoded strings extracted** — all remaining user-facing strings in import-editor, column-mapper, preset-creator, backup-panel, form-editor, json-editor, and category-legend now use `t()` translation calls
 
 ### Testing
+
 - **2,112 tests across 87 files** — all passing
 - chart-renderer: +18 tests (getters, setSelectedNode, setDimUnchanged)
 - column-mapper: +8 tests (prefill, radio toggle, callbacks)
@@ -208,11 +242,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.4.7] — 2026-03-19
 
 ### Fixed
+
 - **Styled tooltips on chart/version actions** — chart action buttons (Rename, Duplicate, Export, Delete) and version action buttons (View, Compare, Restore, Delete) now use the styled `data-tooltip` CSS tooltips instead of the native browser `title` attribute, matching the toolbar tooltip style
 
 ## [3.4.6] — 2026-03-18
 
 ### Fixed
+
 - **i18n hardcoded strings** — wrapped 60+ user-facing strings in `t()` across UI components, editors, renderer, and main.ts fatal error handler
 - **CSS RTL readiness** — converted 30 physical direction properties (`left:`, `margin-left:`, `text-align: left`, etc.) to CSS logical equivalents (`inset-inline-start:`, `margin-inline-start:`, `text-align: start`)
 - **Dark theme contrast** — changed `--text-tertiary` from `#64748b` (3.9:1) to `#94a3b8` (7.3:1), meeting WCAG AA 4.5:1 minimum
@@ -224,6 +260,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Duplicate i18n keys** — removed 8 duplicate aria key entries in `en.ts`
 
 ### Added
+
 - **`contrastRatio()` utility** — WCAG contrast ratio calculator exported from `src/utils/contrast.ts`
 - **`td()` / `tn()` i18n helpers** — locale-aware date and number formatting via `Intl.DateTimeFormat` / `Intl.NumberFormat`
 - **Loading overlay** — reusable `showLoading()` / `hideLoading()` component for async operations
@@ -234,70 +271,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Export dialog** — version checkbox description text
 
 ### Changed
+
 - **Welcome banner** — dismiss button now hints at help recovery: "Got it — click ❓ anytime for help"
 - **Footer separator** — extracted `' · '` to i18n key `footer.separator`; footer stats now use `<span>` elements with tooltips
 
 ### Testing
+
 - 2,063 tests across 85 files — all passing
 
 ## [3.4.5] — 2026-03-18
 
 ### Added
+
 - **Load Sample Org Chart** — button in Help dialog's "Getting Started" section loads a ~20-node demo org showcasing managers, M1s, ICs, advisors, and dotted-line relationships
 
 ### Testing
+
 - 1,965 tests across 76 files — all passing
 
 ## [3.4.4] — 2026-03-18
 
 ### Fixed
+
 - **Preset save prompt regression** — "Save as preset" dialog now correctly triggers when changing any setting (spacing, fonts, alignment, border radius, etc.), not just the 7 color/size fields previously checked
 
 ### Testing
+
 - 1,955 tests across 75 files — all passing
 
 ## [3.4.3] — 2026-03-18
 
 ### Added
+
 - **Tree favicon** — SVG primary favicon with PNG fallbacks (32×32, 16×16) and Apple touch icon (180×180); minimal green tree silhouette on dark background matching theme-color
 - **Grab cursor on settings preview** — preview area now shows a hand cursor to indicate drag-to-pan is available
 
 ### Testing
+
 - 1,945 tests across 74 files — all passing
 
 ## [3.4.2] — 2026-03-16
 
 ### Removed
+
 - **Unused sample-org.ts** — `src/data/sample-org.ts` was never imported; deleted
 - **Stale PPTX artifact** — removed accidentally committed `202603121439-org-chart.pptx` from repo root
 - **Completed plan doc** — deleted `docs/plans/2026-03-14-import-wizard-content.md` (fully implemented)
 
 ### Changed
+
 - **.gitignore** — added `*.pptx` and `npm-tree.json` to prevent future accidental commits
 
 ### Testing
+
 - 1,945 tests across 74 files — all passing
 
 ## [3.4.1] — 2026-03-15
 
 ### Fixed
+
 - **Preview zoom regression** — restored Fit, Reset, zoom percentage, drag-to-pan, and scroll-to-zoom in settings preview (broken in v3.4.0 when ZoomManager was set to null for preview mode)
 - **SettingsEditor cleanup** — `destroy()` now properly calls `previewRenderer.destroy()` to clean up D3 event listeners
 
 ### Added
+
 - **ZoomManager `programmaticOnly` option** — allows creating zoom behavior for programmatic use only (no user interaction), available for future use
 
 ### Testing
+
 - 1,945 tests across 74 files — all passing
 - 14 new tests: zoom-manager programmaticOnly (11), chart-renderer preview (1), settings-editor preview+destroy (2)
 
 ## [3.4.0] — 2026-03-15
 
 ### Security
+
 - **Tree validation on bundle import** — `.arbol.json` imports now validate tree structure (depth, node count, field types) before storing, preventing DoS via malicious files
 - **Upgrade jsdom 28→29** — resolves 6 undici CVEs (0 audit vulnerabilities)
 
 ### Performance
+
 - **O(1) dirty tracking** — replaced JSON.stringify comparison with mutation version counter
 - **O(n) descendant counts** — pre-computed in single bottom-up pass (was O(n²) per-node flattenTree)
 - **O(1) bulk operation lookups** — pre-computed node/parent maps (was O(n) findNodeById per node)
@@ -305,26 +358,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ADVISORS_PER_ROW constant** — extracted magic number from 5 interdependent layout calculations
 
 ### Architecture
+
 - **main.ts decomposition** — split from 1,931→900 lines (53% reduction) into 5 init modules: context-menu-handler, toolbar-builder, footer-builder, comparison-handler, shortcuts-handler
 - **SettingsEditor extraction** — split from 1,517→736 lines into 4 panels: preset-panel, category-panel, settings-io, backup-panel
 - **DOM builder utility** — shared createButton/createFormGroup/createHeading helpers, refactored 4 UI components
 
 ### API Design
+
 - **MappingStore reactive** — now extends EventEmitter (was only store without events)
 - **Standardized event payloads** — all stores emit void (ThemeManager was inconsistent)
 
 ### Regression fixes
+
 - **Chart switch sanitization** — repaired charts now persisted back to IndexedDB
 - **Bulk operations** — collect all nodes before mutation loop (prevents silent skips)
 - **isM1() documented** — comprehensive JSDoc + 9 edge case tests for node type classification
 
 ### Testing
+
 - 1,931 tests across 74 files — all passing
 - 122 new tests: event-emitter (21), E2E workflows (11), dom-builder (22), layout-engine (7), chart-store (14), org-store (6), zoom-manager (5), tree (9), PPTX assertions (23), mapping-store (4)
 
 ## [3.3.1] — 2026-03-15
 
 ### Fixed
+
 - **Silent data loss prevention** — `saveWorkingTree()` now catches IndexedDB failures and shows a toast notification instead of silently losing edits
 - **Crash on early interaction** — guarded `focusMode` references before initialization to prevent `TypeError` when comparison mode triggers during page load
 - **Memory leak** — bounded the redo stack to `MAX_HISTORY` (50 entries), matching the undo stack, preventing unbounded memory growth
@@ -336,12 +394,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **i18n compliance** — replaced 3 hardcoded error strings in import-editor with `t()` calls
 
 ### Testing
+
 - 1,809 tests across 70 files — all passing
 - 8 new tests: redo stack limits (3), IndexedDB blocked/versionchange (3), saveWorkingTree catch (3) (note: 1 test file was added but contains 3 tests)
 
 ## [3.3.0] — 2026-03-15
 
 ### Added
+
 - **Collapsible accordion help dialog** — 13 sections now collapse/expand with chevron indicators; only one section open at a time
 - **Keyboard Shortcuts promoted** — Shortcuts section is now first and expanded by default, displayed as a clean two-column grid with 13 shortcuts (8 new: Ctrl+K, Ctrl+,, ?, arrow keys, Enter, Space, Home/End, Shift+F10)
 - **New keyboard shortcuts** — `?` opens help dialog, `Ctrl+,` opens settings modal
@@ -349,39 +409,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Mobile-friendly welcome** — updated to "Tap, click, or right-click any card…"
 
 ### Changed
+
 - **Help content accuracy overhaul** — every section audited and corrected to match current app state: removed non-existent Sidebar Tabs/Collapse-Expand/Export-Import Settings; fixed menu labels (Tag not Set Category, Focus not Focus on sub-org); updated sidebar, import wizard, settings modal, and export dialog descriptions
 - **i18n compliance** — all hardcoded English strings in help dialog now use `t()` i18n calls
 
 ### Testing
+
 - 1,800 tests across 69 files — all passing
 
 ## [3.2.2] — 2026-03-15
 
 ### Changed
+
 - **Context menu labels** — shortened "Focus on sub-org" → "Focus", "Set Category" → "Tag", "Set as dotted line" / "Remove dotted line" → "Dotted" / "Solid"
 
 ### Added
+
 - **Dotted/Solid toggle** in property panel actions — toggle a node's reporting line between dotted and solid directly from the panel
 
 ### Removed
+
 - **Floating actions toolbar** — the bottom toolbar on card selection was redundant with the context menu and property panel; all its actions remain accessible via those UIs
 
 ### Testing
+
 - 1,786 tests across 69 files — all passing
 
 ## [3.2.1] — 2026-03-15
 
 ### Changed
+
 - **Chart centering** — org chart now centers both horizontally and vertically on initial load, fit-to-content, and reset zoom (previously pinned to top with padding)
 - `centerAtRealSize()` no longer accepts a `padding` parameter — vertical position is always centered
 - `fitToContent()` now centers vertically instead of top-aligning with padding
 
 ### Testing
+
 - 1,794 tests across 70 files — all passing
 
 ## [3.2.0] — 2026-03-15
 
 ### Added
+
 - **Live preview strip** — shared preview area at the top of the settings modal content, visible on all tabs except Backup; per-tab contextual hint text updates automatically on tab switch
 - **Preview renderer** — new `src/renderer/preview-renderer.ts` that uses the full `ChartRenderer` in preview mode — zero rendering divergence with the main chart
 - Preview mode (`preview: true`) on `ChartRenderer` disables keyboard nav, click handlers, legend, and ARIA tree attributes; pan/zoom remains enabled
@@ -396,25 +465,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 12 new i18n strings for preview hints and zoom control labels
 
 ### Changed
+
 - Settings modal content area wrapped in `.settings-content-column` flex container to support the fixed preview strip above scrollable settings
 
 ### Testing
+
 - 1,793 tests across 70 files — all passing
 
 ## [3.1.1] — 2026-03-15
 
 ### Added
+
 - **File type mismatch warnings** — when restoring a backup, importing settings, or importing org data, the app now detects if you selected the wrong file type and shows a helpful message directing you to the correct feature
 
 ### Fixed
+
 - **Category preview readability** — enlarged preview card (52×28 → 64×34px) and increased font sizes; title now displays uppercase
 
 ### Testing
+
 - 1,744 tests across 69 files — all passing
 
 ## [3.1.0] — 2026-03-15
 
 ### Changed
+
 - **Settings panel redesign** — row-based layout matching mockup (label+description left, control+value right)
 - Setting groups rendered as flat sections instead of accordions (sidebar tab nav handles grouping)
 - Custom styled range sliders (teal thumb, thin track) and color swatch pickers
@@ -422,27 +497,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mono-font value display next to range controls
 
 ### Testing
+
 - 1,711 tests across 68 files — all passing
 
 ## [3.0.2] — 2026-03-15
 
 ### Added
+
 - **Command palette: Settings** — ⚙️ Settings action with Ctrl+, shortcut
 - **Command palette: Switch Chart** — lists all non-active charts for quick switching
 - **Property panel: Avg Span of Control** — shows average direct reports per manager in the selected node's subtree
 - **Draggable search bar** — click+drag to reposition the floating search bar on the canvas
 
 ### Fixed
+
 - **Command palette input** — removed focus-visible border on the search input
 - **Floating search bar** — moved from header to canvas overlay matching mockup (pill shape, 🔍 icon, expands on focus)
 - **Clear All Data** — moved inside Backup & Restore section (was showing on every settings tab)
 
 ### Testing
+
 - 1,712 tests across 68 files — all passing
 
 ## [3.0.1] — 2026-03-15
 
 ### Fixed
+
 - **Sidebar UX polish** — reduced side padding, chart list absorbs height (versions + Quick Actions flush at bottom)
 - **Ghost buttons** — added `.btn-ghost` and `.btn-icon` CSS classes; `+` and `+ Save` buttons now transparent
 - **Chart names visible** — action buttons changed from `opacity:0` to `display:none` so they don't steal flex space
@@ -455,18 +535,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Version highlighting** — viewed version gets teal accent highlight (`.version-item.viewing`) matching active chart style
 
 ### Added
+
 - **Compare button in version viewer** — banner now shows Compare · Restore · ✕ Close (was Restore · Close)
 - **Header toolbar dividers** — separators between Undo/Redo | Import/Export | Settings/Theme/Help
 
 ### Removed
+
 - **Footer export button** — redundant with header Export button and Ctrl+E shortcut
 
 ### Testing
+
 - 1,707 tests across 68 files — all passing
 
 ## [3.0.0] — 2026-03-14
 
 ### Added
+
 - **Command Palette**: Ctrl+K opens fuzzy search overlay for quick access to all actions (export, undo, redo, search)
 - **Property Panel**: Right-side contextual panel appears when clicking a node — shows info, edit fields, and action buttons
 - **Floating Actions**: Bottom toolbar with quick action buttons for selected nodes (single and multi-select modes)
@@ -477,38 +561,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Export in header**: 📤 Export button moved to header toolbar
 
 ### Changed
+
 - Sidebar slimmed from 300px 4-tab editor to 200px chart navigator (chart list + versions only)
 - Header buttons styled with ghost theme (transparent background, hover highlight)
 
 ### Testing
+
 - 1,707 tests across 68 files — all passing
 
 ## [2.9.1] — 2026-03-14
 
 ### Added
+
 - **Cross-highlight on hover in side-by-side comparison** — hovering a node in one pane highlights the matching node in the other pane with an amber glow, making it easy to track people across versions
 - **Click-to-select in side-by-side comparison** — click nodes to persistently highlight them across both panes; click again to deselect
 
 ### Fixed
+
 - **"Dim: Off" toggle not working in side-by-side comparison** — toggling dim unchanged had no effect because the internal renderers always used the default `dimUnchanged = true`; now `SideBySideRenderer` exposes `setDimUnchanged()` and propagates the state to both panes
 
 ## [2.9.0] — 2026-03-14
 
 ### Added
+
 - **"Remove entire org" option** — when removing a manager, a choice dialog offers "Reassign reports" (existing flow) or "Remove entire org (N people)" with a danger confirmation before deleting the manager and all their descendants
 - **Side-by-side comparison zoom** — Fit and Reset zoom buttons now work on both panels in version comparison mode via new `SideBySideRenderer.fitToContent()`, `resetZoom()`, and `centerAtRealSize()` methods
 - **Auto-create "Original" version on import** — importing a new chart from JSON or CSV automatically saves an "Original" version snapshot; skipped for bundle imports that already carry their own versions
 
 ### Fixed
+
 - **Search highlighting visual bug** — IC container backgrounds and advisor links were not dimmed during search, causing an uneven appearance; now all four rendering layers (tree links, IC containers, advisor links, nodes) are dimmed consistently
 - **Search highlighting SVG compositing artifact** — applying opacity to `<g>` group elements created compositing layers causing visible color banding; now targets individual `path.link` elements instead
 
 ### Tests
+
 - Added 13 new tests (1,510 → 1,523): search highlighting (8), side-by-side zoom delegation (5)
 
 ## [2.8.0] — 2026-03-14
 
 ### Added
+
 - **Accessibility: SVG chart ARIA tree semantics** — org chart cards now have `role="treeitem"`, `aria-label`, `aria-level`, `aria-expanded`; SVG container has `role="tree"`
 - **Accessibility: Chart keyboard navigation** — Arrow keys navigate the org tree (↑ parent, ↓ child, ←→ siblings), Enter to select, Space for multi-select, Shift+F10 for context menu, Home/End (`src/renderer/keyboard-nav.ts`)
 - **Accessibility: Screen reader announcer** — global `aria-live` region announces search results, undo/redo, chart switching, save, selection changes, theme toggle, focus mode (`src/ui/announcer.ts`)
@@ -531,6 +623,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Decorative emoji `aria-hidden`** — toolbar button emoji wrapped in `<span aria-hidden="true">`
 
 ### Fixed
+
 - **Recursive undo/redo crash** — replaced recursive calls with iterative loop; corrupted snapshots are now skipped gracefully
 - **Color contrast WCAG AA** — `DEFAULT_TITLE_DARK` changed from `#64748b` to `#475569`; `--text-tertiary` updated for both themes; Pastel preset title color fixed
 - **Form labels not linked to inputs** — ~30+ controls now have `htmlFor`/`id` associations; JSON editor textarea, file input, paste textarea have `aria-label`
@@ -548,6 +641,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`textAlign` option extended** — now accepts `'start'` and `'end'` in addition to `'left'`/`'center'`/`'right'`
 
 ### Changed
+
 - **Help dialog expanded** — added 4 new sections: How the Chart Works (IC/Advisor/Manager terminology), Color Categories, Focus Mode, Headcount Badges; updated context menu description, Escape priority chain, Backup/Restore docs
 - **README.md** — fixed incorrect double-click editing claim
 - **AGENTS.md** — updated file count (39→59), added `src/controllers/` directory, updated test count, fixed interactions table
@@ -556,6 +650,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Footer** — added `aria-label="Status bar"`
 
 ### Tests
+
 - Added 153 new tests (1,357 → 1,510) across 7 new test files
 - New: `announcer.test.ts` (10), `toast.test.ts` (9), `input-dialog.test.ts` (10), `welcome-banner.test.ts` (11), `keyboard-nav.test.ts` (26), `accessibility.test.ts` (24), `i18n.test.ts` (26)
 - Updated: `org-store.test.ts` (+6 corrupted snapshot tests), `contrast.test.ts`, `category-store.test.ts`, `chart-editor.test.ts`, `settings-store.test.ts`, `theme-presets.test.ts`
@@ -564,6 +659,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.7.0] — 2026-03-13
 
 ### Refactored
+
 - **CSS utility classes** — extracted 24 utility classes (flex, gap, text, spacing, grid) replacing 28 inline styles
 - **localStorage abstraction** — `IStorage` interface with `browserStorage` default; all 8 store files accept injectable storage
 - **Generic EventEmitter** — `EventEmitter<T>` with typed payloads; ThemeManager now uses `EventEmitter<Theme>`
@@ -571,12 +667,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **D3 data joins** — all 4 render layers converted to `.data().join()` pattern for future incremental updates
 
 ### Tests
+
 - Added 54 new controller tests (focus-mode 16, selection-manager 15, search-controller 11, integration +6)
 - Total: 1,352 tests across 55 files
 
 ## [2.6.0] — 2026-03-13
 
 ### Fixed
+
 - **Undo/redo resilience** — corrupted undo stack entries are now skipped instead of crashing the app
 - **Event listener isolation** — a failing listener no longer prevents other listeners from being notified
 - **Storage error handling** — localStorage writes wrapped in try/catch; IndexedDB quota errors show user-friendly messages
@@ -584,6 +682,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **IndexedDB data validation** — charts loaded from IndexedDB are now sanitized to handle missing/malformed fields
 
 ### Improved
+
 - **Layout performance** — eliminated 4 O(n²) algorithms; pre-computed node lookup maps, cached subtree bounds, single-pass manager level computation
 - **Render performance** — pre-computed category Map for O(1) lookups instead of O(n) find per rendered element
 - **Bundle size** — converted D3 imports from namespace (`import * as d3`) to selective named imports for better tree-shaking
@@ -591,6 +690,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Category import safety** — importing a chart bundle now warns before replacing existing categories
 
 ### Refactored
+
 - Extracted `EventEmitter` base class, eliminating duplicated observer pattern across 3 stores
 - Extracted `dismissible.ts` utility for singleton UI element lifecycle management
 - Deduplicated legend rendering into shared generic method
@@ -598,12 +698,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added JSDoc documentation to all core type interfaces
 
 ### Tests
+
 - Added 68 new tests (1,230 → 1,298): dialog-utils (30), version-viewer (20), dismissible (9), IndexedDB error paths (4), category import warnings (5)
 - Centralized localStorage mock via shared test setup
 
 ## [2.5.0] — 2026-03-13
 
 ### Added
+
 - **Version comparison** — compare any two chart versions (or a version vs the working tree) to see what changed; click "Compare" on any version in the sidebar, then pick a target
 - **Merged diff view** — single chart with color-coded corner badges: Added (green), Removed (red), Moved (purple), Modified (amber); removed nodes shown as ghost cards at their old position
 - **Side-by-side diff view** — dual-pane rendering with old tree on the left and new tree on the right, both annotated with diff badges; toggle between merged and side-by-side via the comparison banner
@@ -611,21 +713,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dim unchanged toggle** — "Dim: On/Off" button in the comparison banner lets you toggle muting of unchanged nodes; when on, unchanged cards fade to gray so changes stand out
 
 ### Fixed
+
 - **Inconsistent diff dimming** — unchanged cards now use uniform fill color overrides instead of group opacity, preventing visual inconsistency between manager cards (dark background) and IC cards (gray container background)
 
 ## [2.4.0] — 2026-03-13
 
 ### Added
+
 - **Chart bundle export** — new "Export" button on each chart in the sidebar opens a dialog to select which versions to include, then downloads a `.arbol.json` bundle containing the chart's working tree, categories, and selected version snapshots
 - **Chart bundle import** — the Import tab auto-detects `.arbol.json` bundle files; users choose to create a new chart or replace the current one; imported versions are added alongside any existing versions
 
 ## [2.3.0] — 2026-03-13
 
 ### Added
+
 - **Duplicate chart** — new "Duplicate" button on each chart in the sidebar copies the working tree and categories into a new chart (versions are not copied); auto-switches to the copy
 - **Import destination choice** — importing CSV/JSON now shows a dialog asking whether to create a new chart or replace the current one (previously always replaced)
 
 ### Fixed
+
 - **Dotted line disabled for ICs** — the "Set as dotted line" context menu option is now disabled for Individual Contributor nodes (leaf nodes under M1 managers), which have no connecting lines to make dotted
 - **New chart shows empty tree** — creating a new chart now properly loads the empty default tree instead of continuing to display the previous chart's data
 - **False unsaved changes warning** — creating a new chart no longer triggers a spurious "unsaved changes" warning when switching charts
@@ -633,11 +739,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.2.1] — 2026-03-13
 
 ### Fixed
+
 - Standardized all exported filenames to use `yyyymmddhhmm-` prefix (backup files and PPTX chart exports were using inconsistent date formats)
 
 ## [2.2.0] — 2026-03-13
 
 ### Added
+
 - **Text alignment** — new `textAlign` option (left / center / right) for card name and title text, with `textPaddingHorizontal` for left/right-aligned padding; syncs to PPTX export
 - **Font family** — configurable `fontFamily` with 8 PowerPoint-safe options (Calibri, Arial, Verdana, Georgia, Tahoma, Trebuchet MS, Segoe UI, Microsoft Sans Serif); replaces all hardcoded Calibri references
 - **Card border radius** — new `cardBorderRadius` option (0–15px) for rounded card corners; PPTX export uses `roundRect` shape when radius > 0
@@ -646,6 +754,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Select control type** — new dropdown control type in settings editor for enum options (textAlign, fontFamily)
 
 ### Changed
+
 - IC container background now starts at the vertical midpoint of the M1 manager card (instead of the bottom edge), eliminating visual gaps with rounded card corners
 - IC container fill and IC container border radius settings moved to IC Options group
 - All 8 existing theme presets now include explicit `textAlign`, `cardBorderRadius`, `fontFamily`, and `icContainerBorderRadius` values
@@ -653,6 +762,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.1.0] — 2026-03-13
 
 ### Added
+
 - **Backup & Restore** — new "Backup & Restore" section in the Settings tab to export and import all app data as a single `.arbol-backup.json` file
 - Backup bundles all charts, version snapshots, settings, theme, CSV mapping presets, and custom theme presets
 - Two restore strategies: **Replace All** (wipe current data and restore from backup) or **Merge** (add new charts, keep existing ones)
@@ -662,6 +772,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.0.0] — 2026-03-13
 
 ### Added
+
 - **Multiple org charts** — create, rename, and delete independent org charts; switch between them from the new "Charts" sidebar tab or the header chart name
 - **Version snapshots** — save named point-in-time snapshots of any chart; view in read-only mode, restore, or delete
 - **IndexedDB storage** — org chart data and categories moved from localStorage to IndexedDB for greater capacity (multiple charts × versions)
@@ -674,6 +785,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Auto-migration** — existing localStorage data automatically migrates to IndexedDB on first load; no data loss on upgrade
 
 ### Changed
+
 - PPTX export filename now includes the chart name
 - Status bar now displays the active chart name
 - Undo/redo stacks reset when switching charts or restoring versions
@@ -682,17 +794,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.9.0] — 2026-03-13
 
 ### Added
+
 - **Configurable legend rows** — new `legendRows` setting in the "Categories Legend" section controls how many rows the category legend uses; columns are auto-calculated (`ceil(count / rows)`) with row-major fill order
 - Multi-column layout applies to all three legend renderers: SVG canvas, HTML overlay, and PPTX export
 - Default `legendRows = 0` preserves existing single-column behavior
 
 ### Changed
+
 - PPTX legend items are now properly vertically centered within the legend box
 - PPTX legend column spacing tightened for a more compact multi-column layout
 
 ## [1.8.0] — 2026-03-13
 
 ### Added
+
 - **Configurable name & title text colors** — new `nameColor` and `titleColor` settings in the Typography section, persisted across sessions and included in all 8 theme presets
 - **Auto-contrast text colors for categories** — when a category's background color is set or changed, name and title text colors are auto-computed using WCAG 2.1 relative luminance for readability
 - **Per-category text color overrides** — each category row in Settings now has Name and Title color pickers, auto-initialized with contrast-safe defaults but manually adjustable
@@ -702,6 +817,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PPTX export respects both global and per-category text colors
 
 ### Changed
+
 - Title text color is no longer hardcoded to `#64748b` — it now uses the configurable `titleColor` setting
 - Name text color is no longer inherited black — it now uses the configurable `nameColor` setting
 - `ColorCategory` interface extended with optional `nameColor` and `titleColor` fields (backward-compatible — old data auto-migrated)
@@ -709,26 +825,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.7.2] — 2026-03-13
 
 ### Changed
+
 - **Timestamped filenames on all exports** — mapping preset exports, settings exports, and PPTX exports now all use `yyyymmddhhmm-` prefix for consistent file naming
 - Extracted shared `generateTimestamp()` utility from PPTX exporter into `src/utils/filename.ts`
 
 ## [1.7.1] — 2026-03-13
 
 ### Security
+
 - **Replaced xlsx with exceljs** — `xlsx` 0.18.5 had high-severity prototype pollution (CVE-2023-30533) and ReDoS vulnerabilities with no fix on npm; replaced with actively-maintained `exceljs`
 
 ### Changed
+
 - Bumped `vitest` and `@vitest/coverage-v8` from 4.0.18 to 4.1.0
 
 ## [1.7.0] — 2026-03-13
 
 ### Added
+
 - **Privacy messaging** — README and in-app Help dialog now clearly state all data stays in your browser (no server, no tracking, no accounts)
 - **Clear All Data** — button in both the Help dialog and Settings panel to delete all local data with a danger confirmation
 
 ## [1.6.0] — 2026-03-13
 
 ### Added
+
 - **Headcount badge** — optional badge on each manager card showing total number of reports
   - Grey rounded-corner box positioned on the right edge of the card, vertically centered
   - Enable via Settings → Headcount Badge → Show Headcount
@@ -738,12 +859,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **1000-person sample org** — `public/big-org-1000.csv` with 8 levels of depth for testing large orgs
 
 ### Fixed
+
 - Default layout for first-time users is now "Default" instead of "Compact"
 - PPTX badge text no longer wraps to 2 lines for multi-digit numbers
 
 ## [1.5.2] — 2026-03-12
 
 ### Fixed
+
 - **PPTX export now matches on-screen 100% zoom** — slide is dynamically sized to the chart's bounding box at 1:1 scale (96 DPI) instead of shrinking/stretching to fit a fixed slide
   - Font sizes, card colors, stroke widths, and link styles are forwarded from renderer settings
   - Safety cap at PowerPoint's 56″ max slide dimension (only scales down if exceeded)
@@ -752,6 +875,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.1] — 2026-03-12
 
 ### Changed
+
 - **Scaled categories legend** — legend now sizes proportionally with each layout preset instead of using fixed 8px values
   - New `legendFontSize` option on `RendererOptions` controls all legend dimensions (font, swatch, padding, row height)
   - Per-preset values: Compact (8px), Default (12px), Spacious (14px), Presentation (16px)
@@ -759,6 +883,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.0] — 2026-03-12
 
 ### Changed
+
 - **Rebalanced layout presets** — larger default sizes for better readability
   - Default preset now uses previous Presentation values (160×34 cards, 11/9px fonts)
   - New Spacious (190×42) and Presentation (220×50) presets for extra-large displays
@@ -769,6 +894,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.4.0] — 2026-03-12
 
 ### Added
+
 - **Dotted-line reporting** — optional dashed connections indicating a person works for one manager but reports to another
   - `dottedLine` boolean on `OrgNode`, `setDottedLine()` store method with undo/redo
   - Dashed SVG links (`stroke-dasharray`) and dashed PPTX connectors (`dashType`)
@@ -776,6 +902,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configurable `dottedLineDash` setting (default `6,4`)
 
 ### Changed
+
 - **Real-size initial zoom** — org chart now loads at actual pixel size (1:1 scale) instead of fitting to viewport
   - New `centerAtRealSize()` method on `ZoomManager` — positions chart at scale=1, centered horizontally, top-aligned
   - "⟲ Reset" button returns to real size; "⊞ Fit" button still fits to viewport
@@ -785,11 +912,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.1] — 2026-03-12
 
 ### Security
+
 - Pinned `xlsx` dependency to exact version `0.18.5` (known prototype pollution and ReDoS vulnerabilities in `^0.18.x` range)
 - Hardened Content Security Policy with `form-action`, `frame-ancestors`, `base-uri`, `object-src`, and `connect-src` directives
 - Replaced `innerHTML` usage in import editor drop zone with safe DOM construction
 
 ### Fixed
+
 - Added missing `FileReader.onerror` handler in import editor preset file loader
 - Wrapped all async context menu actions (Move, Remove, bulk operations) in try/catch to prevent unhandled promise rejections
 - Added `console.warn` logging to 5 silent `catch` blocks in stores (`CategoryStore`, `MappingStore`, `SettingsStore`) and `main.ts`
@@ -797,11 +926,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `as any` type assertions in chart renderer with proper `CardDatum` D3 generics
 
 ### Improved
+
 - **Performance**: `flattenTree()` rewritten as iterative (avoids stack overflow on deep trees), `cloneTree()` uses `structuredClone`, search results memoized with auto-invalidation
 - **Accessibility**: Added `:focus-visible` outlines on all buttons/inputs, skip-navigation link, `@media (prefers-reduced-motion: reduce)`, focus traps in all modal dialogs, `aria-hidden` on decorative emoji icons
 - **Reusability**: Extracted shared `dialog-utils.ts` with `createOverlay()`, `createDialogPanel()`, and `trapFocus()` — refactored confirm dialog, manager picker, and help dialog to use them
 
 ### Added
+
 - ESLint + Prettier tooling with `lint`, `lint:fix`, `format`, `format:check`, and `type-check` npm scripts
 - `<meta name="description">` and `<meta name="theme-color">` tags in `index.html`
 - `.prettierrc` and `.prettierignore` configuration files
@@ -811,6 +942,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.3.0] — 2026-03-12
 
 ### Added
+
 - **Collapsible accordion sections** in Settings — fine-tuning groups collapsed by default, presets and categories expanded
 - **Per-group reset buttons** — reset individual setting groups to defaults
 - **Settings quick-filter** — search input at top of Settings to find specific settings
@@ -820,6 +952,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Selection count** — shown in footer center when multi-selecting
 
 ### Changed
+
 - **Sidebar tabs consolidated** from 5 (Add, Load, Edit, Settings, Utilities) to 3 (People, Import, Settings)
 - **People tab** — combines Add Person + Edit Person workflows
 - **Import tab** — combines file import, text normalization, and collapsible JSON editor
@@ -828,20 +961,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Footer center** restored GitHub links
 
 ### Removed
+
 - Standalone Edit (JSON) tab — now a collapsible section in Import tab
 - Standalone Utilities tab — text normalization moved into Import tab
 - Mini card preview in Settings
 
 ### Fixed
+
 - Zoom indicator showed 150% as the default view — now displays percentage relative to fit-to-content base scale so the default always reads 100%
 
 ### Changed (internal)
+
 - Renamed PAL to Advisor in user-facing text
 - Reset zoom button now calls fitToContent() instead of resetZoom()
 
 ## [1.2.0] — 2026-03-12
 
 ### Added
+
 - **Text normalization on import** — Title Case / UPPERCASE / lowercase options for name and title fields independently, available in the import preview step for all import types (CSV, JSON, XLSX)
 - **Utilities sidebar tab** — new tab with text normalization for the existing org chart (apply Title Case / UPPERCASE / lowercase to all names and/or titles with a single click)
 - Normalization dropdowns in Column Mapper UI, saved as part of mapping presets
@@ -854,6 +991,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] — 2026-03-12
 
 ### Added
+
 - Per-node color categories with customizable labels and colors
 - Default categories: Open Position (amber), Offer Pending (blue), Future Start (purple)
 - `CategoryStore` for managing category definitions with localStorage persistence
@@ -868,12 +1006,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 103 new tests (569 total across 27 files)
 
 ### Fixed
+
 - CSV import now handles trailing HR system metadata (e.g., Workday "Applied filters:" blocks) via RFC 4180 multi-line quoted field support
 - Rows with empty name fields are silently skipped during CSV import
 - Duplicate IDs (Format A) and duplicate names (Format B/C) now throw a clear error instead of silently overwriting data
 - Circular reference errors now show the full cycle path (e.g., "Alice → Carol → Bob → Alice")
 
 ### Changed
+
 - `MAX_NODES` limit of 10,000 enforced on CSV import to prevent browser crashes
 
 ## [1.0.0] — 2026-03-11
@@ -881,6 +1021,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial release. See [docs/roadmap.md](docs/roadmap.md) for the full feature breakdown.
 
 ### Added
+
 - Interactive org chart visualization with D3.js SVG rendering
 - Three editing modes: Form (Add), Import (Load), JSON (Edit)
 - Right-click context menu with Edit, Add Child, Focus, Move, Remove

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -61,3 +61,11 @@
 **Decision**: Vanilla TypeScript for all non-SVG UI (sidebar, dialogs, menus). D3 owns the SVG exclusively.
 **Alternatives considered**: React with refs for D3 integration, Svelte.
 **Consequences**: No virtual DOM overhead. Full control over DOM manipulation. Requires manual DOM helpers for UI components (`createElement`, `appendChild`, `textContent`). Every UI component is a class or function that returns/manipulates DOM elements directly.
+
+### ADR-007: Atomic backup restore with rollback
+**Date**: 2026-05-05
+**Status**: Accepted
+**Context**: `restoreFullReplace()` deleted all existing charts before writing backup data. A failure mid-write left the app in an empty/partial state with no recovery path.
+**Decision**: Validate all backup data upfront, snapshot existing data, then delete+write. If writing fails, roll back by re-inserting the snapshot.
+**Alternatives considered**: (1) Two-phase IndexedDB transaction — not feasible with the current `ChartDB` abstraction. (2) Write-then-swap with temporary stores — adds complexity for marginal benefit.
+**Consequences**: Slightly higher memory usage during restore (holds both old and new data). Guarantees users never lose data due to a restore failure. Rollback is best-effort (if rollback itself fails, data may still be lost — but this is the same as the original situation and strictly better than guaranteed loss).

--- a/src/editor/settings/backup-panel.ts
+++ b/src/editor/settings/backup-panel.ts
@@ -49,7 +49,10 @@ export class BackupPanel {
         const backup = await createBackup(this.chartDB);
         downloadBackup(backup);
       } catch (e) {
-        showToast(t('settings.backup_failed', { error: e instanceof Error ? e.message : String(e) }), 'error');
+        showToast(
+          t('settings.backup_failed', { error: e instanceof Error ? e.message : String(e) }),
+          'error',
+        );
       }
     });
     backupBtnGroup.appendChild(backupBtn);
@@ -104,16 +107,29 @@ export class BackupPanel {
 
           if (strategy === 'replace') {
             // Auto-backup before destructive replace
+            let replaceBackupFailed = false;
             try {
               const autoBackup = await createBackup(this.chartDB);
               downloadBackup(autoBackup);
             } catch {
-              // If auto-backup fails, still let the user proceed
+              replaceBackupFailed = true;
+            }
+
+            if (replaceBackupFailed) {
+              const proceed = await showConfirmDialog({
+                title: t('backup.clear_no_backup_title'),
+                message: t('backup.clear_no_backup_message'),
+                confirmLabel: t('backup.clear_no_backup_confirm'),
+                danger: true,
+              });
+              if (!proceed) return;
             }
 
             const confirmed = await showConfirmDialog({
               title: t('backup.replace_title'),
-              message: t('backup.replace_message'),
+              message: t(
+                replaceBackupFailed ? 'backup.replace_message_no_backup' : 'backup.replace_message',
+              ),
               confirmLabel: t('backup.replace_confirm'),
               danger: true,
             });
@@ -135,7 +151,10 @@ export class BackupPanel {
             window.location.reload();
           }
         } catch (e) {
-          showToast(t('settings.restore_failed', { error: e instanceof Error ? e.message : String(e) }), 'error');
+          showToast(
+            t('settings.restore_failed', { error: e instanceof Error ? e.message : String(e) }),
+            'error',
+          );
         }
       });
       document.body.appendChild(input);
@@ -158,11 +177,23 @@ export class BackupPanel {
       'background:rgba(244,63,94,0.1);color:var(--danger);border:1px solid rgba(244,63,94,0.2);';
     clearDataBtn.addEventListener('click', async () => {
       // Auto-backup before destructive clear
+      let backupFailed = false;
       try {
         const autoBackup = await createBackup(this.chartDB);
         downloadBackup(autoBackup);
       } catch {
-        // If auto-backup fails, still allow the user to proceed
+        backupFailed = true;
+      }
+
+      // If backup failed, warn the user and require explicit acknowledgment
+      if (backupFailed) {
+        const proceed = await showConfirmDialog({
+          title: t('backup.clear_no_backup_title'),
+          message: t('backup.clear_no_backup_message'),
+          confirmLabel: t('backup.clear_no_backup_confirm'),
+          danger: true,
+        });
+        if (!proceed) return;
       }
 
       const confirmed = await showConfirmDialog({

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -88,7 +88,8 @@ const en: Record<string, string> = {
   'analytics.section.categories': 'Category Distribution',
   'analytics.uncategorized': 'Uncategorized',
   'analytics.no_categories': 'No categories in use',
-  'analytics.disclaimer': 'Metrics are computed from the current chart structure and are for reference only. Verify independently before making organizational decisions.',
+  'analytics.disclaimer':
+    'Metrics are computed from the current chart structure and are for reference only. Verify independently before making organizational decisions.',
 
   // ─── Analytics Tooltips ─────────────────────────────────────────────
   'analytics.tooltip.headcount': 'Total people, split by managers, ICs, and advisors',
@@ -260,9 +261,8 @@ const en: Record<string, string> = {
   'toolbar.import_aria': 'Import data',
   'toolbar.import_label': 'Import',
 
-
   // ─── Focus Mode ────────────────────────────────────────────────────
-  'focus.viewing': '🔎 Viewing {name}\'s org',
+  'focus.viewing': "🔎 Viewing {name}'s org",
   'focus.show_full': 'Show full org',
   'focus.entered': 'Focused on {name} org',
   'focus.exited': 'Showing full org',
@@ -291,7 +291,8 @@ const en: Record<string, string> = {
   'dialog.save_version.label': 'Version name',
   'dialog.save_version.placeholder': 'e.g. Q1 2024 Plan',
   'dialog.unsaved.title': 'Unsaved Changes',
-  'dialog.unsaved.message': 'You have unsaved changes. Would you like to save a version before switching?',
+  'dialog.unsaved.message':
+    'You have unsaved changes. Would you like to save a version before switching?',
   'dialog.unsaved.confirm': 'Switch without saving',
   'dialog.remove_person.title': 'Remove Person',
   'dialog.remove_person.message': 'Remove "{name}"? You can undo this with Ctrl+Z.',
@@ -304,37 +305,46 @@ const en: Record<string, string> = {
   'dialog.remove_manager.reassign': 'Reassign reports',
   'dialog.remove_manager.remove_all': 'Remove entire org ({count} people)',
   'dialog.remove_manager.remove_all_confirm_title': 'Remove Entire Org',
-  'dialog.remove_manager.remove_all_confirm_message': 'This will remove "{name}" and {count} people in their org. You can undo this with Ctrl+Z.',
+  'dialog.remove_manager.remove_all_confirm_message':
+    'This will remove "{name}" and {count} people in their org. You can undo this with Ctrl+Z.',
   'dialog.remove_manager.remove_all_confirm': 'Remove All',
   'dialog.large_export.title': 'Large Org Chart',
-  'dialog.large_export.message': 'This org chart is too large to fit at full size on a PowerPoint slide (max 56″). It will be scaled down and may be hard to read.\n\nTip: Right-click a manager and choose "Focus on sub-org" to export a smaller section instead.',
+  'dialog.large_export.message':
+    'This org chart is too large to fit at full size on a PowerPoint slide (max 56″). It will be scaled down and may be hard to read.\n\nTip: Right-click a manager and choose "Focus on sub-org" to export a smaller section instead.',
   'dialog.large_export.confirm': 'Export anyway',
   'dialog.delete_chart.title': 'Delete Chart',
   'dialog.delete_chart.message': 'Are you sure you want to delete "{name}"? This cannot be undone.',
   'dialog.delete_chart.confirm': 'Delete',
   'dialog.delete_version.title': 'Delete Version',
-  'dialog.delete_version.message': 'Are you sure you want to delete version "{name}"? This cannot be undone.',
+  'dialog.delete_version.message':
+    'Are you sure you want to delete version "{name}"? This cannot be undone.',
   'dialog.delete_version.confirm': 'Delete',
   'dialog.clear_data.title': 'Clear All Data',
-  'dialog.clear_data.message': 'This will permanently delete all your org charts, versions, settings, themes, and preferences. This cannot be undone.\n\nAre you sure?',
+  'dialog.clear_data.message':
+    'This will permanently delete all your org charts, versions, settings, themes, and preferences. This cannot be undone.\n\nAre you sure?',
   'dialog.clear_data.confirm': 'Delete everything',
   'dialog.replace_data.title': 'Replace All Data',
-  'dialog.replace_data.message': 'This will permanently replace all existing charts, versions, and settings with the backup data. A backup of your current data has been downloaded.\n\nContinue?',
+  'dialog.replace_data.message':
+    'This will permanently replace all existing charts, versions, and settings with the backup data. A backup of your current data has been downloaded.\n\nContinue?',
   'dialog.replace_data.confirm': 'Replace everything',
   'dialog.merge_complete.title': 'Merge Complete',
-  'dialog.merge_complete.message': 'Added {chartsAdded} chart(s) and {versionsAdded} version(s). Skipped {chartsSkipped} chart(s) that already existed.\n\nThe page will reload to apply changes.',
+  'dialog.merge_complete.message':
+    'Added {chartsAdded} chart(s) and {versionsAdded} version(s). Skipped {chartsSkipped} chart(s) that already existed.\n\nThe page will reload to apply changes.',
   'dialog.import_destination.title': 'Import Destination',
-  'dialog.import_destination.message': 'Would you like to create a new chart from this import, or replace the current chart?',
+  'dialog.import_destination.message':
+    'Would you like to create a new chart from this import, or replace the current chart?',
   'dialog.import_destination.new_chart': 'New Chart',
   'dialog.import_destination.chart_name_label': 'Chart name',
   'dialog.import_destination.chart_name_placeholder': 'e.g. Engineering Org',
   'dialog.import_bundle.title': 'Import Chart Bundle',
-  'dialog.import_bundle.message': 'Import "{name}" with {count} version(s). Create a new chart or replace the current one?',
+  'dialog.import_bundle.message':
+    'Import "{name}" with {count} version(s). Create a new chart or replace the current one?',
   'dialog.import_bundle.new_chart': 'New chart',
   'dialog.import_bundle.replace': 'Replace current',
 
   'dialog.replace_mappings.title': 'Replace Level Mappings?',
-  'dialog.replace_mappings.message': 'This chart has existing level mappings that will be replaced by the imported bundle\'s mappings. Continue?',
+  'dialog.replace_mappings.message':
+    "This chart has existing level mappings that will be replaced by the imported bundle's mappings. Continue?",
   'dialog.replace_mappings.confirm': 'Replace mappings',
   'dialog.replace_mappings.cancel': 'Cancel',
 
@@ -400,7 +410,8 @@ const en: Record<string, string> = {
   'version_viewer.close': '✕ Close',
 
   // ─── Welcome Banner ────────────────────────────────────────────────
-  'welcome.message': 'Welcome to Arbol! This is a sample chart \u2014 tap, click, or right-click any card to edit, add, or move people. Click \u2753 for help.',
+  'welcome.message':
+    'Welcome to Arbol! This is a sample chart \u2014 tap, click, or right-click any card to edit, add, or move people. Click \u2753 for help.',
   'welcome.dismiss': 'Got it \u2014 click \u2753 anytime for help',
   'welcome.aria': 'Welcome guide',
   'welcome.dismiss_aria': 'Dismiss welcome message',
@@ -480,7 +491,8 @@ const en: Record<string, string> = {
   'import.nothing_to_parse': 'Nothing to parse — paste JSON or CSV data above.',
   'import.file_too_large': 'File too large ({size}MB). Maximum is 10MB.',
   'import.parsing_file': 'Parsing {name}…',
-  'import.encrypted_file': 'This file is encrypted or rights-protected. Open it in Excel, save as a new unprotected .xlsx or .csv, then import that file.',
+  'import.encrypted_file':
+    'This file is encrypted or rights-protected. Open it in Excel, save as a new unprotected .xlsx or .csv, then import that file.',
   'import.parse_failed': 'Could not parse as JSON or CSV. Check your data format.',
   'import.auto_detect_failed': 'Auto-detection failed. Please map columns below.',
   'import.invalid_tree': 'Invalid org tree: root must have id, name, and title',
@@ -492,7 +504,8 @@ const en: Record<string, string> = {
   'import.csv_example_name': 'name,title,manager_name\nJane Doe,CEO,\nJohn Smith,VP Eng,Jane Doe',
   'import.json_format': 'JSON Format',
   'import.json_nested': 'Nested tree',
-  'import.json_example': '{\n  "id": "ceo",\n  "name": "Jane Doe",\n  "title": "CEO",\n  "children": [\n    { "id": "vp", "name": "John", "title": "VP" }\n  ]\n}',
+  'import.json_example':
+    '{\n  "id": "ceo",\n  "name": "Jane Doe",\n  "title": "CEO",\n  "children": [\n    { "id": "vp", "name": "John", "title": "VP" }\n  ]\n}',
   'import.name_format': 'Name Format',
   'import.title_format': 'Title Format',
   'import.normalization_heading': 'Text Normalization',
@@ -504,9 +517,11 @@ const en: Record<string, string> = {
   'import.bundle_no_versions': 'Chart bundle "{name}" with no versions',
   'import.invalid_bundle_version': 'Unsupported chart bundle version: {version}',
   'import.invalid_bundle_missing': 'Invalid chart bundle: missing chart name or working tree',
-  'import.invalid_bundle_root': 'Invalid chart bundle: working tree root must have id, name, and title',
+  'import.invalid_bundle_root':
+    'Invalid chart bundle: working tree root must have id, name, and title',
   'import.invalid_bundle_versions': 'Invalid chart bundle: versions must be an array',
-  'import.invalid_bundle_version_entry': 'Invalid chart bundle: each version must have name and tree',
+  'import.invalid_bundle_version_entry':
+    'Invalid chart bundle: each version must have name and tree',
   'import.loading': 'Loading...',
   'import.drop_or': 'Drop file or ',
   'import.original_version_name': 'Original',
@@ -514,7 +529,8 @@ const en: Record<string, string> = {
 
   // ─── Column Mapper ─────────────────────────────────────────────────
   'column_mapper.heading': 'Map CSV Columns',
-  'column_mapper.description': 'We couldn\'t auto-detect your CSV format. Please map each column below.',
+  'column_mapper.description':
+    "We couldn't auto-detect your CSV format. Please map each column below.",
   'column_mapper.name_column': 'Person Name Column',
   'column_mapper.title_column': 'Job Title Column',
   'column_mapper.parent_column_name': 'Reports To (Name)',
@@ -540,8 +556,10 @@ const en: Record<string, string> = {
   'column_mapper.select_placeholder': '— Select —',
   'column_mapper.none_placeholder': '— None —',
   'column_mapper.error_required': 'Please select a column for Name, Title, and Reports To.',
-  'column_mapper.error_id_required': 'When using "By ID" parent references, the Person ID column must be mapped.',
-  'column_mapper.error_duplicates': 'Each column can only be mapped to one field. Please remove duplicates.',
+  'column_mapper.error_id_required':
+    'When using "By ID" parent references, the Person ID column must be mapped.',
+  'column_mapper.error_duplicates':
+    'Each column can only be mapped to one field. Please remove duplicates.',
 
   // ─── Preset Creator ────────────────────────────────────────────────
   'preset_creator.heading': 'Create Mapping Preset',
@@ -563,7 +581,8 @@ const en: Record<string, string> = {
   'preset_creator.save': 'Save',
   'preset_creator.error_name_required': 'Preset name is required.',
   'preset_creator.error_columns_required': 'Name, Title, and Reports To columns are required.',
-  'preset_creator.error_id_required': 'ID column is required when parent reference type is "By ID".',
+  'preset_creator.error_id_required':
+    'ID column is required when parent reference type is "By ID".',
 
   // ─── Import Editor ─────────────────────────────────────────────────
   'import_editor.preset_heading': 'Mapping Preset',
@@ -674,7 +693,8 @@ const en: Record<string, string> = {
   'settings.save_preset_button': 'Save',
   'settings.save_preset_skip': 'No',
   'settings.save_preset_prompt_title': 'Save as Preset?',
-  'settings.save_preset_prompt_label': 'Your settings have changed. Save them as a reusable preset?',
+  'settings.save_preset_prompt_label':
+    'Your settings have changed. Save them as a reusable preset?',
   'settings.layout_label': 'Layout',
 
   // ─── Setting Group Titles ──────────────────────────────────────────
@@ -749,7 +769,8 @@ const en: Record<string, string> = {
   'theme.emerald.name': 'Emerald',
   'theme.emerald.description': 'The default green-accented theme with clean white cards',
   'theme.corporate_blue.name': 'Corporate Blue',
-  'theme.corporate_blue.description': 'Professional blue-toned theme suited for business presentations',
+  'theme.corporate_blue.description':
+    'Professional blue-toned theme suited for business presentations',
   'theme.forest.name': 'Forest',
   'theme.forest.description': 'Deep forest greens evoking a natural, organic feel',
   'theme.sunset_warm.name': 'Sunset Warm',
@@ -761,7 +782,8 @@ const en: Record<string, string> = {
   'theme.pastel.name': 'Pastel',
   'theme.pastel.description': 'Soft pink and purple tones for a gentle, approachable look',
   'theme.high_contrast.name': 'High Contrast',
-  'theme.high_contrast.description': 'Maximum-accessibility theme with bold borders and stark contrasts',
+  'theme.high_contrast.description':
+    'Maximum-accessibility theme with bold borders and stark contrasts',
   'theme.ocean_teal.name': 'Ocean Teal',
   'theme.ocean_teal.description': 'Modern teal-accented theme with left-aligned text',
   'theme.stone.name': 'Stone',
@@ -793,7 +815,8 @@ const en: Record<string, string> = {
   'org_store.error_node_not_found': 'Node "{id}" not found',
   'org_store.error_parent_not_found': 'Parent node "{id}" not found',
   'org_store.error_reassign_self': 'Cannot reassign children to the node being removed',
-  'org_store.error_reassign_descendant': 'Cannot reassign children to a descendant of the node being removed',
+  'org_store.error_reassign_descendant':
+    'Cannot reassign children to a descendant of the node being removed',
   'org_store.error_dotted_root': 'Cannot set dotted line on root node',
   'org_store.error_dotted_ic': 'Cannot set dotted line on an IC (Individual Contributor) node',
   'org_store.error_move_root': 'Cannot move root node',
@@ -813,18 +836,27 @@ const en: Record<string, string> = {
   'org_store.error_invalid_children': 'Invalid children on node "{id}": expected an array',
 
   // ─── CSV Parser ────────────────────────────────────────────────────
-  'csv.error_no_name_title': 'Unrecognizable CSV format: could not find required "name" and "title" columns.',
-  'csv.error_no_parent': 'Unrecognizable CSV format: could not find parent reference column (parent_id, manager_name, or reports_to).',
+  'csv.error_no_name_title':
+    'Unrecognizable CSV format: could not find required "name" and "title" columns.',
+  'csv.error_no_parent':
+    'Unrecognizable CSV format: could not find parent reference column (parent_id, manager_name, or reports_to).',
   'csv.error_header_only': 'CSV must contain a header row and at least one data row.',
   'csv.error_min_rows_1': 'CSV must contain at least 1 data row (need at least a root node).',
   'csv.error_min_rows_2': 'CSV must contain at least 2 data rows.',
-  'csv.error_max_nodes': 'CSV contains {count} data rows, which exceeds the maximum of {max}. Please reduce the dataset.',
-  'csv.error_missing_columns': 'Column mapping error: the following columns were not found in the CSV headers: {missing}. Available headers: {available}',
-  'csv.error_duplicate_id': 'Duplicate ID "{id}": "{name1}" and "{name2}" share the same identifier.',
-  'csv.error_duplicate_name': 'Duplicate name "{name}": two people share the same name. Use ID-based import (with a unique alias column) to distinguish them.',
-  'csv.error_orphan_id': 'Orphan reference: node "{name}" references parent_id "{ref}" which does not exist.',
-  'csv.error_orphan_name': 'Orphan reference: node "{name}" references parent "{ref}" which does not exist.',
-  'csv.error_no_root': 'No root node found (every node has a parent reference — possible circular reference).',
+  'csv.error_max_nodes':
+    'CSV contains {count} data rows, which exceeds the maximum of {max}. Please reduce the dataset.',
+  'csv.error_missing_columns':
+    'Column mapping error: the following columns were not found in the CSV headers: {missing}. Available headers: {available}',
+  'csv.error_duplicate_id':
+    'Duplicate ID "{id}": "{name1}" and "{name2}" share the same identifier.',
+  'csv.error_duplicate_name':
+    'Duplicate name "{name}": two people share the same name. Use ID-based import (with a unique alias column) to distinguish them.',
+  'csv.error_orphan_id':
+    'Orphan reference: node "{name}" references parent_id "{ref}" which does not exist.',
+  'csv.error_orphan_name':
+    'Orphan reference: node "{name}" references parent "{ref}" which does not exist.',
+  'csv.error_no_root':
+    'No root node found (every node has a parent reference — possible circular reference).',
   'csv.error_multiple_roots': 'Multiple roots detected: {roots}. Only one root is allowed.',
   'csv.error_circular': 'Circular reference: {path}',
 
@@ -837,35 +869,46 @@ const en: Record<string, string> = {
   'help.sample_org_button': '🌳 Load Sample Org Chart',
   'help.sample_org_aria': 'Load a sample organization chart',
   'help.sample_org_confirm_title': 'Load Sample Org?',
-  'help.sample_org_confirm_message': 'This will replace the current chart with a sample organization. You can undo this action.',
+  'help.sample_org_confirm_message':
+    'This will replace the current chart with a sample organization. You can undo this action.',
   'help.section_toggle_aria': 'Toggle {section} section',
 
   // Help: Getting Started
   'help.getting_started.title': 'Getting Started',
-  'help.getting_started.pan_zoom': 'The chart displays your organization hierarchy. Pan by dragging the canvas, zoom with scroll wheel.',
-  'help.getting_started.right_click': 'Right-click any card for edit, add, move, or remove options.',
-  'help.getting_started.sidebar': 'The sidebar manages charts and versions. Use the toolbar buttons for Settings (⚙️), Import (📂), and Export (📤).',
+  'help.getting_started.pan_zoom':
+    'The chart displays your organization hierarchy. Pan by dragging the canvas, zoom with scroll wheel.',
+  'help.getting_started.right_click':
+    'Right-click any card for edit, add, move, or remove options.',
+  'help.getting_started.sidebar':
+    'The sidebar manages charts and versions. Use the toolbar buttons for Settings (⚙️), Import (📂), and Export (📤).',
 
   // Help: How the Chart Works
   'help.chart_works.title': 'How the Chart Works',
   'help.chart_works.managers_label': 'Managers',
   'help.chart_works.managers_desc': ' — People with direct reports. Connected by tree lines.',
   'help.chart_works.ics_label': 'ICs (Individual Contributors)',
-  'help.chart_works.ics_desc': ' — Employees without direct reports. Shown in compact vertical stacks under their manager.',
+  'help.chart_works.ics_desc':
+    ' — Employees without direct reports. Shown in compact vertical stacks under their manager.',
   'help.chart_works.advisors_label': 'Advisors',
-  'help.chart_works.advisors_desc': ' \u2014 Staff who report directly to a senior manager (one who manages other managers), such as a Chief of Staff or Executive Assistant. Shown in a special 2-column layout beside the manager\'s card.',
-  'help.chart_works.auto_detect': 'The chart automatically detects these roles based on the hierarchy — no manual configuration needed.',
+  'help.chart_works.advisors_desc':
+    " \u2014 Staff who report directly to a senior manager (one who manages other managers), such as a Chief of Staff or Executive Assistant. Shown in a special 2-column layout beside the manager's card.",
+  'help.chart_works.auto_detect':
+    'The chart automatically detects these roles based on the hierarchy — no manual configuration needed.',
 
   // Help: Toolbar & Sidebar
   'help.sidebar_tabs.title': 'Toolbar & Sidebar',
   'help.sidebar_tabs.sidebar_label': 'Sidebar',
-  'help.sidebar_tabs.sidebar_desc': ' — Browse, create, rename, and switch between org charts. Save, view, compare, and restore named version snapshots.',
+  'help.sidebar_tabs.sidebar_desc':
+    ' — Browse, create, rename, and switch between org charts. Save, view, compare, and restore named version snapshots.',
   'help.sidebar_tabs.settings_label': 'Settings (⚙️)',
-  'help.sidebar_tabs.settings_desc': ' — Opens a modal to adjust card sizes, spacing, colors, typography, and categories. Includes theme presets and a live preview.',
+  'help.sidebar_tabs.settings_desc':
+    ' — Opens a modal to adjust card sizes, spacing, colors, typography, and categories. Includes theme presets and a live preview.',
   'help.sidebar_tabs.import_label': 'Import (📂)',
-  'help.sidebar_tabs.import_desc': ' — Opens a step-by-step wizard to import org data from JSON or CSV files, with column mapping and text normalization.',
+  'help.sidebar_tabs.import_desc':
+    ' — Opens a step-by-step wizard to import org data from JSON or CSV files, with column mapping and text normalization.',
   'help.sidebar_tabs.export_label': 'Export (📤)',
-  'help.sidebar_tabs.export_desc': ' — Downloads the chart as an editable PowerPoint file. Choose which saved versions to include.',
+  'help.sidebar_tabs.export_desc':
+    ' — Downloads the chart as an editable PowerPoint file. Choose which saved versions to include.',
 
   // Help: Charts & Versions
   'help.charts_versions.title': 'Charts & Versions',
@@ -874,24 +917,31 @@ const en: Record<string, string> = {
   'help.charts_versions.multiple_2': '. Create, rename, and switch between charts in the ',
   'help.charts_versions.multiple_tab': 'sidebar',
   'help.charts_versions.multiple_3': '.',
-  'help.charts_versions.header': 'Hover over the active chart in the sidebar to access Rename, Duplicate, Export, and Delete actions.',
+  'help.charts_versions.header':
+    'Hover over the active chart in the sidebar to access Rename, Duplicate, Export, and Delete actions.',
   'help.charts_versions.save_label': 'Save a version',
-  'help.charts_versions.save_desc': ' — Take a named snapshot of the current chart using the Save button in the Versions section of the sidebar.',
+  'help.charts_versions.save_desc':
+    ' — Take a named snapshot of the current chart using the Save button in the Versions section of the sidebar.',
   'help.charts_versions.view_label': 'View a version',
-  'help.charts_versions.view_desc': ' — Opens a read-only preview. Click Restore to make it the working chart, or Close to return.',
-  'help.charts_versions.unsaved': 'If you have unsaved changes when switching charts or restoring a version, you\'ll be warned first.',
+  'help.charts_versions.view_desc':
+    ' — Opens a read-only preview. Click Restore to make it the working chart, or Close to return.',
+  'help.charts_versions.unsaved':
+    "If you have unsaved changes when switching charts or restoring a version, you'll be warned first.",
 
   // Help: Importing Data
   'help.importing.title': 'Importing Data',
   'help.importing.how_1': 'Click the ',
   'help.importing.how_strong': '📂 Import',
   'help.importing.how_2': ' button in the toolbar, or use the command palette (Ctrl+K).',
-  'help.importing.wizard': 'The import wizard guides you through four steps: choose a source, map columns (CSV only), preview the data, and select a destination.',
+  'help.importing.wizard':
+    'The import wizard guides you through four steps: choose a source, map columns (CSV only), preview the data, and select a destination.',
   'help.importing.json_label': 'JSON',
   'help.importing.json_desc': ' — Nested tree format. Recognized automatically.',
   'help.importing.csv_label': 'CSV',
-  'help.importing.csv_desc': ' — Flat table with columns for name, title, and parent. The column mapper lets you match your headers to the required fields and save presets.',
-  'help.importing.normalize': 'Text normalization (Title Case, UPPERCASE, lowercase) can be applied during the preview step.',
+  'help.importing.csv_desc':
+    ' — Flat table with columns for name, title, and parent. The column mapper lets you match your headers to the required fields and save presets.',
+  'help.importing.normalize':
+    'Text normalization (Title Case, UPPERCASE, lowercase) can be applied during the preview step.',
   'help.importing.limit': 'Maximum 10,000 people per import.',
 
   // Help: Chart Interactions
@@ -899,19 +949,25 @@ const en: Record<string, string> = {
   'help.interactions.click_label': 'Click',
   'help.interactions.click_desc': ' — Select and highlight a card.',
   'help.interactions.right_click_label': 'Right-click',
-  'help.interactions.right_click_desc': ' \u2014 Context menu with Edit, Add, Focus, Category, Dotted/Solid, Move, and Remove.',
+  'help.interactions.right_click_desc':
+    ' \u2014 Context menu with Edit, Add, Focus, Category, Dotted/Solid, Move, and Remove.',
   'help.interactions.shift_click_label': 'Shift+click',
-  'help.interactions.shift_click_desc': ' \u2014 Multi-select cards, then right-click for bulk Category, Move all, or Remove all.',
+  'help.interactions.shift_click_desc':
+    ' \u2014 Multi-select cards, then right-click for bulk Category, Move all, or Remove all.',
   'help.interactions.escape_label': 'Escape',
-  'help.interactions.escape_desc': ' — Dismiss version viewer, clear search, exit focus mode, clear multi-selection, or deselect (in that priority order).',
+  'help.interactions.escape_desc':
+    ' — Dismiss version viewer, clear search, exit focus mode, clear multi-selection, or deselect (in that priority order).',
   'help.interactions.inline_label': 'Inline editing',
-  'help.interactions.inline_desc': ' — Right-click a card and choose Edit to edit directly on the card.',
+  'help.interactions.inline_desc':
+    ' — Right-click a card and choose Edit to edit directly on the card.',
   'help.interactions.search_label': 'Search',
-  'help.interactions.search_desc': ' — Type in the search bar to highlight matching people. Non-matches are dimmed.',
+  'help.interactions.search_desc':
+    ' — Type in the search bar to highlight matching people. Non-matches are dimmed.',
 
   // Help: Color Categories
   'help.categories.title': 'Color Categories',
-  'help.categories.assign_1': 'Assign a color category to any person by right-clicking their card and choosing ',
+  'help.categories.assign_1':
+    'Assign a color category to any person by right-clicking their card and choosing ',
   'help.categories.assign_strong': 'Category',
   'help.categories.assign_2': '.',
   'help.categories.defaults_1': 'Each chart has its own set of categories. Default categories: ',
@@ -924,61 +980,77 @@ const en: Record<string, string> = {
   'help.categories.manage_1': 'Add, edit, or delete categories in the ',
   'help.categories.manage_strong': 'Settings',
   'help.categories.manage_2': ' modal under the Categories tab.',
-  'help.categories.legend': 'A color legend appears on the chart when categories are in use and is included in PowerPoint exports.',
+  'help.categories.legend':
+    'A color legend appears on the chart when categories are in use and is included in PowerPoint exports.',
 
   // Help: Focus Mode
   'help.focus_mode.title': 'Focus Mode',
   'help.focus_mode.enter_1': 'Right-click any manager and choose ',
   'help.focus_mode.enter_strong': 'Focus',
-  'help.focus_mode.enter_2': ' to view only that person\'s team as a standalone chart.',
+  'help.focus_mode.enter_2': " to view only that person's team as a standalone chart.",
   'help.focus_mode.exit_1': 'Press ',
   'help.focus_mode.exit_kbd': 'Escape',
   'help.focus_mode.exit_2': ' or click ',
   'help.focus_mode.exit_strong': 'Show full org',
   'help.focus_mode.exit_3': ' in the banner to return to the full chart.',
-  'help.focus_mode.export': 'PowerPoint export and status bar stats automatically reflect the focused sub-org.',
+  'help.focus_mode.export':
+    'PowerPoint export and status bar stats automatically reflect the focused sub-org.',
 
   // Help: Headcount Badges
   'help.headcount.title': 'Headcount Badges',
-  'help.headcount.enable_1': 'Managers can display a badge showing their total headcount (number of people in their org). Enable this in the ',
+  'help.headcount.enable_1':
+    'Managers can display a badge showing their total headcount (number of people in their org). Enable this in the ',
   'help.headcount.enable_settings': 'Settings',
   'help.headcount.enable_2': ' modal under the ',
   'help.headcount.enable_strong': 'Badges',
   'help.headcount.enable_3': ' tab.',
-  'help.headcount.customize': 'Badge appearance (color, size, radius) can be customized in the same Badges tab.',
+  'help.headcount.customize':
+    'Badge appearance (color, size, radius) can be customized in the same Badges tab.',
 
   // Help: Analytics
   'help.analytics.title': 'Analytics',
   'help.analytics.headcount_label': 'Headcount Overview — ',
-  'help.analytics.headcount_desc': 'Total number of people in the org, broken down by role type (Managers, ICs, Advisors). Useful for understanding composition at a glance.',
+  'help.analytics.headcount_desc':
+    'Total number of people in the org, broken down by role type (Managers, ICs, Advisors). Useful for understanding composition at a glance.',
   'help.analytics.depth_label': 'Org Depth — ',
-  'help.analytics.depth_desc': 'The maximum number of layers from root to the deepest leaf. Deeper orgs have more management layers; flatter orgs have fewer. Average leaf depth shows where most people sit.',
+  'help.analytics.depth_desc':
+    'The maximum number of layers from root to the deepest leaf. Deeper orgs have more management layers; flatter orgs have fewer. Average leaf depth shows where most people sit.',
   'help.analytics.ratio_label': 'Manager-to-IC Ratio — ',
-  'help.analytics.ratio_desc': 'The ratio of managers to individual contributors (non-managers). Shown as "1 : X" — higher X means leaner management overhead. Useful for benchmarking.',
+  'help.analytics.ratio_desc':
+    'The ratio of managers to individual contributors (non-managers). Shown as "1 : X" — higher X means leaner management overhead. Useful for benchmarking.',
   'help.analytics.span_label': 'Span of Control — ',
-  'help.analytics.span_desc': 'Average number of direct reports per manager, with min/max range. Wide spans (>10) may signal overload; narrow spans (<3) may signal unnecessary layers.',
+  'help.analytics.span_desc':
+    'Average number of direct reports per manager, with min/max range. Wide spans (>10) may signal overload; narrow spans (<3) may signal unnecessary layers.',
   'help.analytics.alerts_label': 'Alerts — ',
-  'help.analytics.alerts_desc': 'Flags structural anomalies: managers with too many reports (wide span), too few (narrow span), or exactly one (single-child, possibly redundant layer).',
+  'help.analytics.alerts_desc':
+    'Flags structural anomalies: managers with too many reports (wide span), too few (narrow span), or exactly one (single-child, possibly redundant layer).',
 
   // Help: Your Data
   'help.your_data.title': 'Your Data',
-  'help.your_data.privacy_1': 'Arbol runs entirely in your browser. Your org charts, versions, and preferences are stored in your browser\'s storage (IndexedDB and localStorage) and ',
+  'help.your_data.privacy_1':
+    "Arbol runs entirely in your browser. Your org charts, versions, and preferences are stored in your browser's storage (IndexedDB and localStorage) and ",
   'help.your_data.privacy_strong': 'never leave your device',
   'help.your_data.privacy_2': '.',
-  'help.your_data.no_server': 'There is no server, no database, no tracking, and no account required. Your data stays on your machine\u200b–\u200bnobody else can see it.',
+  'help.your_data.no_server':
+    'There is no server, no database, no tracking, and no account required. Your data stays on your machine\u200b–\u200bnobody else can see it.',
 
   // Help: Settings & Persistence
   'help.settings.title': 'Settings',
-  'help.settings.auto_save': 'All visual settings auto-save to your browser and restore on next visit.',
-  'help.settings.modal': 'Open Settings (⚙️ button or Ctrl+,) to access 10 tabs: Presets, Layout, Typography, Cards, Connectors, IC Options, Advisors, Badges, Categories, and Backup.',
-  'help.settings.presets': 'Theme presets apply a full set of colors and spacing in one click. You can also save your own custom presets.',
+  'help.settings.auto_save':
+    'All visual settings auto-save to your browser and restore on next visit.',
+  'help.settings.modal':
+    'Open Settings (⚙️ button or Ctrl+,) to access 10 tabs: Presets, Layout, Typography, Cards, Connectors, IC Options, Advisors, Badges, Categories, and Backup.',
+  'help.settings.presets':
+    'Theme presets apply a full set of colors and spacing in one click. You can also save your own custom presets.',
   'help.settings.preview': 'A live preview on the right shows changes as you adjust settings.',
   'help.settings.backup_1': 'Use ',
   'help.settings.backup_strong': 'Create Backup',
-  'help.settings.backup_2': ' in the Backup tab to save all your charts, versions, and settings as a single file.',
+  'help.settings.backup_2':
+    ' in the Backup tab to save all your charts, versions, and settings as a single file.',
   'help.settings.restore_1': 'Use ',
   'help.settings.restore_strong': 'Restore',
-  'help.settings.restore_2': ' to load a backup. You can choose to replace all data or merge with your existing charts.',
+  'help.settings.restore_2':
+    ' to load a backup. You can choose to replace all data or merge with your existing charts.',
 
   // Help: Keyboard Shortcuts
   'help.shortcuts.title': 'Keyboard Shortcuts',
@@ -999,14 +1071,17 @@ const en: Record<string, string> = {
   // Help: Exporting
   'help.exporting.title': 'Exporting',
   'help.exporting.pptx_label': 'Export PPTX',
-  'help.exporting.pptx_desc': ' — Downloads the chart as an editable PowerPoint file with native shapes and text.',
-  'help.exporting.versions': 'The export dialog lets you select which saved versions to include — each version becomes a separate slide.',
+  'help.exporting.pptx_desc':
+    ' — Downloads the chart as an editable PowerPoint file with native shapes and text.',
+  'help.exporting.versions':
+    'The export dialog lets you select which saved versions to include — each version becomes a separate slide.',
   'help.exporting.scale': 'The export auto-scales to fit a widescreen slide.',
 
   // Help: Links
   'help.links.title': 'Links',
   'help.links.built_with': '✦ Built with Arbol — https://github.com/pedrofuentes/arbol',
-  'help.links.report_bugs': 'Report bugs & request features — https://github.com/pedrofuentes/arbol/issues',
+  'help.links.report_bugs':
+    'Report bugs & request features — https://github.com/pedrofuentes/arbol/issues',
 
   // ─── Comparison Banner ─────────────────────────────────────────────
   'comparison.working_tree': 'Working tree',
@@ -1022,7 +1097,8 @@ const en: Record<string, string> = {
 
   // ─── Import Wizard Steps ──────────────────────────────────────────
   'import_wizard.source_title': 'Choose your data source',
-  'import_wizard.source_desc': 'Upload a file or paste data directly. We support CSV, JSON, and Excel formats.',
+  'import_wizard.source_desc':
+    'Upload a file or paste data directly. We support CSV, JSON, and Excel formats.',
   'import_wizard.drop_text': 'Drop a file here or click to browse',
   'import_wizard.drop_hint': 'CSV, JSON, or XLSX · Max 10,000 people',
   'import_wizard.file_aria': 'Choose file to import',
@@ -1061,8 +1137,8 @@ const en: Record<string, string> = {
   'toolbar.export_label': 'Export',
 
   // ─── Settings: Descriptions ─────────────────────────────────────────
-  'settings.desc.node_width': 'Width of each person\'s card in the chart',
-  'settings.desc.node_height': 'Height of each person\'s card',
+  'settings.desc.node_width': "Width of each person's card in the chart",
+  'settings.desc.node_height': "Height of each person's card",
   'settings.desc.horizontal_spacing': 'Minimum gap between cards at the same level',
   'settings.desc.branch_spacing': 'Gap between separate branches of the tree',
   'settings.desc.top_vertical_spacing': 'Space from a manager card to the connector line below',
@@ -1076,7 +1152,7 @@ const en: Record<string, string> = {
   'settings.desc.advisor_bottom_gap': 'Space below advisor cards',
   'settings.desc.advisor_row_gap': 'Vertical gap between advisor card rows',
   'settings.desc.advisor_center_gap': 'Horizontal gap between left and right advisor columns',
-  'settings.desc.name_font_size': 'Font size for the person\'s name on each card',
+  'settings.desc.name_font_size': "Font size for the person's name on each card",
   'settings.desc.title_font_size': 'Font size for the job title on each card',
   'settings.desc.text_padding_top': 'Space from the top of the card to the first line of text',
   'settings.desc.text_gap': 'Space between the name and title text lines',
@@ -1107,20 +1183,29 @@ const en: Record<string, string> = {
   'settings.desc.legend_rows': 'Number of rows for the category legend (0 = auto-fit)',
 
   // ─── Settings: Section Descriptions ─────────────────────────────────
-  'settings.section_desc.presets': 'Choose a visual theme or save your current settings as a custom preset.',
-  'settings.section_desc.categories': 'Define color categories to highlight special roles like open positions or pending offers.',
-  'settings.section_desc.card_dimensions': 'Control the size of each person\'s card in the org chart.',
+  'settings.section_desc.presets':
+    'Choose a visual theme or save your current settings as a custom preset.',
+  'settings.section_desc.categories':
+    'Define color categories to highlight special roles like open positions or pending offers.',
+  'settings.section_desc.card_dimensions':
+    "Control the size of each person's card in the org chart.",
   'settings.section_desc.tree_spacing': 'Adjust the gaps between cards and branches in the tree.',
-  'settings.section_desc.ic_options': 'Configure how individual contributors are displayed in stacked groups.',
-  'settings.section_desc.advisor_options': 'Control spacing for advisor nodes shown alongside managers.',
-  'settings.section_desc.typography': 'Customize fonts, sizes, colors, and text alignment for card text.',
+  'settings.section_desc.ic_options':
+    'Configure how individual contributors are displayed in stacked groups.',
+  'settings.section_desc.advisor_options':
+    'Control spacing for advisor nodes shown alongside managers.',
+  'settings.section_desc.typography':
+    'Customize fonts, sizes, colors, and text alignment for card text.',
   'settings.section_desc.link_style': 'Style the connector lines between cards in the org tree.',
-  'settings.section_desc.card_style': 'Customize card borders, background color, and corner rounding.',
+  'settings.section_desc.card_style':
+    'Customize card borders, background color, and corner rounding.',
   'settings.section_desc.headcount_badge': 'Show and style a headcount badge on manager cards.',
   'settings.section_desc.level_badge': 'Show and style a level indicator badge on all cards.',
-  'settings.section_desc.categories_legend': 'Configure how the category color legend appears on the chart.',
+  'settings.section_desc.categories_legend':
+    'Configure how the category color legend appears on the chart.',
   'settings.section_desc.settings_io': 'Export or import your settings configuration as a file.',
-  'settings.section_desc.backup_restore': 'Create full backups of all charts, versions, and settings.',
+  'settings.section_desc.backup_restore':
+    'Create full backups of all charts, versions, and settings.',
 
   // ─── Settings: Layout Preset Descriptions ───────────────────────────
   'settings.layout_compact_desc': 'Tight spacing for large orgs',
@@ -1143,7 +1228,8 @@ const en: Record<string, string> = {
   // ─── Settings: Category Enhancements ────────────────────────────────
   'settings.category_text_colors': 'Text colors:',
   'settings.category_confirm_delete': 'Delete "{label}"?',
-  'settings.category_confirm_delete_message': 'People using this category will revert to the default card color.',
+  'settings.category_confirm_delete_message':
+    'People using this category will revert to the default card color.',
   'settings.category_preview_name': 'Name',
   'settings.category_preview_title': 'Title',
 
@@ -1175,9 +1261,11 @@ const en: Record<string, string> = {
   'export_dialog.cancel': 'Cancel',
   'export_dialog.export': 'Export',
   'restore_dialog.title': 'Restore from Backup',
-  'restore_dialog.summary': '{chartCount} chart(s), {versionCount} version(s) \u00b7 Created {backupDate} \u00b7 v{appVersion}',
+  'restore_dialog.summary':
+    '{chartCount} chart(s), {versionCount} version(s) \u00b7 Created {backupDate} \u00b7 v{appVersion}',
   'restore_dialog.how': 'How would you like to restore?',
-  'restore_dialog.replace_all': '\ud83d\udd04 Replace All \u2014 wipe current data and restore from backup',
+  'restore_dialog.replace_all':
+    '\ud83d\udd04 Replace All \u2014 wipe current data and restore from backup',
   'restore_dialog.merge': '\u2795 Merge \u2014 add new charts, keep existing ones',
   'restore_dialog.cancel': 'Cancel',
   'comparison.dim_on': 'Dim: On',
@@ -1221,17 +1309,26 @@ const en: Record<string, string> = {
   'backup.backup_failed': 'Backup failed: {message}',
   'backup.restore_btn': '\ud83d\udcc2 Restore',
   'backup.replace_title': 'Replace All Data',
-  'backup.replace_message': 'This will permanently replace all existing charts, versions, and settings with the backup data. A backup of your current data has been downloaded.\n\nContinue?',
+  'backup.replace_message':
+    'This will permanently replace all existing charts, versions, and settings with the backup data. A backup of your current data has been downloaded.\n\nContinue?',
+  'backup.replace_message_no_backup':
+    'This will permanently replace all existing charts, versions, and settings with the backup data. No backup of your current data was created.\n\nContinue?',
   'backup.replace_confirm': 'Replace everything',
   'backup.merge_title': 'Merge Complete',
-  'backup.merge_message': 'Added {chartsAdded} chart(s) and {versionsAdded} version(s). Skipped {chartsSkipped} chart(s) that already existed.\n\nThe page will reload to apply changes.',
+  'backup.merge_message':
+    'Added {chartsAdded} chart(s) and {versionsAdded} version(s). Skipped {chartsSkipped} chart(s) that already existed.\n\nThe page will reload to apply changes.',
   'backup.merge_confirm': 'OK',
   'backup.restore_failed': 'Restore failed: {message}',
   'backup.clear_btn': '\ud83d\uddd1 Clear All Data',
   'backup.clear_aria': 'Clear all local data',
   'backup.clear_title': 'Clear All Data',
-  'backup.clear_message': 'This will permanently delete all your org charts, versions, settings, themes, and preferences. This cannot be undone.\n\nAre you sure?',
+  'backup.clear_message':
+    'This will permanently delete all your org charts, versions, settings, themes, and preferences. This cannot be undone.\n\nAre you sure?',
   'backup.clear_confirm': 'Delete everything',
+  'backup.clear_no_backup_title': 'Backup Failed',
+  'backup.clear_no_backup_message':
+    'An automatic backup could not be created. If you proceed, your data will be permanently deleted with no way to recover it.\n\nAre you sure you want to continue without a backup?',
+  'backup.clear_no_backup_confirm': 'Continue without backup',
   'settings_io.export_btn': '\ud83d\udcbe Export',
   'settings_io.import_btn': '\ud83d\udcc2 Import',
   'settings_io.file_too_large': 'Settings file too large (max 1MB).',
@@ -1250,15 +1347,19 @@ const en: Record<string, string> = {
   'export.default_filename': 'org-chart',
   'app.fatal_error': 'Failed to start Arbol',
   'app.unexpected_error': 'An unexpected error occurred',
-  'app.refresh_hint': 'Try refreshing the page. If the issue persists, clear your browser data for this site.',
+  'app.refresh_hint':
+    'Try refreshing the page. If the issue persists, clear your browser data for this site.',
 
   // ─── Help & Docs ──────────────────────────────────────────────────
-  'column_mapper.parent_ref_help': 'By Name matches the parent column to people\'s names. By ID matches a unique identifier.',
+  'column_mapper.parent_ref_help':
+    "By Name matches the parent column to people's names. By ID matches a unique identifier.",
   'footer.ics_tooltip': 'Individual Contributors \u2014 employees without direct reports',
   'help.comparison.title': 'Version Comparison',
-  'help.comparison.desc': 'Use the side-by-side comparison view to see what changed between two versions of your chart. Added, removed, and moved people are highlighted.',
+  'help.comparison.desc':
+    'Use the side-by-side comparison view to see what changed between two versions of your chart. Added, removed, and moved people are highlighted.',
   'help.interactions.dotted_label': 'Dotted lines',
-  'help.interactions.dotted_desc': ' \u2014 Toggle any link to a dotted line via right-click \u2192 Dotted/Solid. Useful for indicating temporary or informal reporting relationships.',
+  'help.interactions.dotted_desc':
+    ' \u2014 Toggle any link to a dotted line via right-click \u2192 Dotted/Solid. Useful for indicating temporary or informal reporting relationships.',
   'export_dialog.versions_hint': 'Select which saved versions to include as additional slides.',
   'export.format_label': 'Format',
   'export.format_pptx': 'PowerPoint (.pptx)',
@@ -1275,12 +1376,14 @@ const en: Record<string, string> = {
   'chart_export_dialog.versions_hint': 'Select which saved versions to include in the export.',
   // ─── Level Mapping ────────────────────────────────────────────────
   'settings.group.level_mapping': 'Level Mapping',
-  'settings.section_desc.level_mapping': 'Define how raw level values map to display titles on cards.',
+  'settings.section_desc.level_mapping':
+    'Define how raw level values map to display titles on cards.',
   'settings.level_mapping_section': 'Level Mapping',
   'settings.label.display_mode': 'Title Display',
   'settings.label.display_mode_original': 'Original Title',
   'settings.label.display_mode_mapped': 'Mapped Title',
-  'settings.desc.display_mode': 'When set to Mapped, the job title on cards is replaced with the mapped display title for that level.',
+  'settings.desc.display_mode':
+    'When set to Mapped, the job title on cards is replaced with the mapped display title for that level.',
   'settings.label.add_mapping': 'Add Mapping',
   'settings.label.raw_level': 'Raw Level',
   'settings.label.display_title': 'IC / Default Title',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -88,7 +88,8 @@ const es: Record<string, string> = {
   'analytics.section.categories': 'Distribución por categoría',
   'analytics.uncategorized': 'Sin categoría',
   'analytics.no_categories': 'Sin categorías en uso',
-  'analytics.disclaimer': 'Las métricas se calculan a partir de la estructura actual del organigrama y son solo de referencia. Verifique de manera independiente antes de tomar decisiones organizacionales.',
+  'analytics.disclaimer':
+    'Las métricas se calculan a partir de la estructura actual del organigrama y son solo de referencia. Verifique de manera independiente antes de tomar decisiones organizacionales.',
 
   // ─── Context Menu ──────────────────────────────────────────────────
   'menu.edit': 'Editar',
@@ -206,9 +207,8 @@ const es: Record<string, string> = {
   'toolbar.import_aria': 'Importar datos',
   'toolbar.import_label': 'Importar',
 
-
   // ─── Focus Mode ────────────────────────────────────────────────────
-  'focus.viewing': '🔎 Viewing {name}\'s org',
+  'focus.viewing': "🔎 Viewing {name}'s org",
   'focus.show_full': 'Mostrar organigrama completo',
   'focus.entered': 'Enfocado en la organización de {name}',
   'focus.exited': 'Mostrando organigrama completo',
@@ -236,7 +236,8 @@ const es: Record<string, string> = {
   'dialog.save_version.label': 'Nombre de la versión',
   'dialog.save_version.placeholder': 'ej. Plan Q1 2024',
   'dialog.unsaved.title': 'Cambios sin guardar',
-  'dialog.unsaved.message': '¿Tiene cambios sin guardar. Desea guardar una versión antes de cambiar?',
+  'dialog.unsaved.message':
+    '¿Tiene cambios sin guardar. Desea guardar una versión antes de cambiar?',
   'dialog.unsaved.confirm': 'Cambiar sin guardar',
   'dialog.remove_person.title': 'Eliminar persona',
   'dialog.remove_person.message': '¿Eliminar "{name}"? Puede deshacer esto con Ctrl+Z.',
@@ -249,32 +250,41 @@ const es: Record<string, string> = {
   'dialog.remove_manager.reassign': 'Reasignar reportes',
   'dialog.remove_manager.remove_all': 'Eliminar organización completa ({count} personas)',
   'dialog.remove_manager.remove_all_confirm_title': 'Eliminar organización completa',
-  'dialog.remove_manager.remove_all_confirm_message': 'Esto eliminará a "{name}" y {count} personas de su organización. Puede deshacer esto con Ctrl+Z.',
+  'dialog.remove_manager.remove_all_confirm_message':
+    'Esto eliminará a "{name}" y {count} personas de su organización. Puede deshacer esto con Ctrl+Z.',
   'dialog.remove_manager.remove_all_confirm': 'Eliminar todos',
   'dialog.large_export.title': 'Organigrama grande',
-  'dialog.large_export.message': 'Este organigrama es demasiado grande para caber a tamaño completo en una diapositiva de PowerPoint (máx. 56″). Se reducirá de escala y podría ser difícil de leer.\n\nConsejo: Haga clic derecho en un gerente y elija "Enfocar" para exportar una sección más pequeña.',
+  'dialog.large_export.message':
+    'Este organigrama es demasiado grande para caber a tamaño completo en una diapositiva de PowerPoint (máx. 56″). Se reducirá de escala y podría ser difícil de leer.\n\nConsejo: Haga clic derecho en un gerente y elija "Enfocar" para exportar una sección más pequeña.',
   'dialog.large_export.confirm': 'Exportar de todos modos',
   'dialog.delete_chart.title': 'Eliminar organigrama',
-  'dialog.delete_chart.message': '¿Está seguro de que desea eliminar "{name}"? Esta acción no se puede deshacer.',
+  'dialog.delete_chart.message':
+    '¿Está seguro de que desea eliminar "{name}"? Esta acción no se puede deshacer.',
   'dialog.delete_chart.confirm': 'Eliminar',
   'dialog.delete_version.title': 'Eliminar versión',
-  'dialog.delete_version.message': '¿Está seguro de que desea eliminar la versión "{name}"? Esta acción no se puede deshacer.',
+  'dialog.delete_version.message':
+    '¿Está seguro de que desea eliminar la versión "{name}"? Esta acción no se puede deshacer.',
   'dialog.delete_version.confirm': 'Eliminar',
   'dialog.clear_data.title': 'Borrar todos los datos',
-  'dialog.clear_data.message': 'Esto eliminará permanentemente todos sus organigramas, versiones, configuración, temas y preferencias. Esta acción no se puede deshacer.\n\n¿Está seguro?',
+  'dialog.clear_data.message':
+    'Esto eliminará permanentemente todos sus organigramas, versiones, configuración, temas y preferencias. Esta acción no se puede deshacer.\n\n¿Está seguro?',
   'dialog.clear_data.confirm': 'Borrar todo',
   'dialog.replace_data.title': 'Reemplazar todos los datos',
-  'dialog.replace_data.message': 'Esto reemplazará permanentemente todos los organigramas, versiones y configuración existentes con los datos del respaldo. Se descargó un respaldo de sus datos actuales.\n\n¿Continuar?',
+  'dialog.replace_data.message':
+    'Esto reemplazará permanentemente todos los organigramas, versiones y configuración existentes con los datos del respaldo. Se descargó un respaldo de sus datos actuales.\n\n¿Continuar?',
   'dialog.replace_data.confirm': 'Reemplazar todo',
   'dialog.merge_complete.title': 'Combinación completa',
-  'dialog.merge_complete.message': 'Se agregaron {chartsAdded} organigrama(s) y {versionsAdded} versión(es). Se omitieron {chartsSkipped} organigrama(s) que ya existían.\n\nLa página se recargará para aplicar los cambios.',
+  'dialog.merge_complete.message':
+    'Se agregaron {chartsAdded} organigrama(s) y {versionsAdded} versión(es). Se omitieron {chartsSkipped} organigrama(s) que ya existían.\n\nLa página se recargará para aplicar los cambios.',
   'dialog.import_destination.title': 'Destino de importación',
-  'dialog.import_destination.message': '¿Desea crear un nuevo organigrama con esta importación o reemplazar el organigrama actual?',
+  'dialog.import_destination.message':
+    '¿Desea crear un nuevo organigrama con esta importación o reemplazar el organigrama actual?',
   'dialog.import_destination.new_chart': 'Nuevo organigrama',
   'dialog.import_destination.chart_name_label': 'Nombre del organigrama',
   'dialog.import_destination.chart_name_placeholder': 'ej. Org. de Ingeniería',
   'dialog.import_bundle.title': 'Importar paquete de organigrama',
-  'dialog.import_bundle.message': 'Importar "{name}" con {count} versión(es). ¿Crear un nuevo organigrama o reemplazar el actual?',
+  'dialog.import_bundle.message':
+    'Importar "{name}" con {count} versión(es). ¿Crear un nuevo organigrama o reemplazar el actual?',
   'dialog.import_bundle.new_chart': 'Nuevo organigrama',
   'dialog.import_bundle.replace': 'Reemplazar actual',
 
@@ -420,7 +430,8 @@ const es: Record<string, string> = {
   'import.nothing_to_parse': 'Nada que analizar — pegue datos JSON o CSV arriba.',
   'import.file_too_large': 'Archivo demasiado grande ({size}MB). El máximo es 10MB.',
   'import.parsing_file': 'Analizando {name}…',
-  'import.encrypted_file': 'Este archivo está cifrado o protegido. Ábralo en Excel, guárdelo como un nuevo archivo .xlsx o .csv sin protección e impórtelo.',
+  'import.encrypted_file':
+    'Este archivo está cifrado o protegido. Ábralo en Excel, guárdelo como un nuevo archivo .xlsx o .csv sin protección e impórtelo.',
   'import.parse_failed': 'No se pudo analizar como JSON o CSV. Verifique el formato de sus datos.',
   'import.auto_detect_failed': 'La detección automática falló. Mapee las columnas a continuación.',
   'import.invalid_tree': 'Árbol de organización no válido: la raíz debe tener id, nombre y cargo',
@@ -432,7 +443,8 @@ const es: Record<string, string> = {
   'import.csv_example_name': 'name,title,manager_name\nJane Doe,CEO,\nJohn Smith,VP Eng,Jane Doe',
   'import.json_format': 'Formato JSON',
   'import.json_nested': 'Árbol anidado',
-  'import.json_example': '{\n  "id": "ceo",\n  "name": "Jane Doe",\n  "title": "CEO",\n  "children": [\n    { "id": "vp", "name": "John", "title": "VP" }\n  ]\n}',
+  'import.json_example':
+    '{\n  "id": "ceo",\n  "name": "Jane Doe",\n  "title": "CEO",\n  "children": [\n    { "id": "vp", "name": "John", "title": "VP" }\n  ]\n}',
   'import.name_format': 'Formato de nombre',
   'import.title_format': 'Formato de cargo',
   'import.normalization_heading': 'Normalización de texto',
@@ -443,10 +455,13 @@ const es: Record<string, string> = {
   'import.bundle_with_versions': 'Paquete de organigrama "{name}" con {count} versión(es)',
   'import.bundle_no_versions': 'Paquete de organigrama "{name}" sin versiones',
   'import.invalid_bundle_version': 'Versión de paquete no soportada: {version}',
-  'import.invalid_bundle_missing': 'Paquete no válido: falta el nombre del organigrama o el árbol de trabajo',
-  'import.invalid_bundle_root': 'Paquete no válido: la raíz del árbol de trabajo debe tener id, nombre y cargo',
+  'import.invalid_bundle_missing':
+    'Paquete no válido: falta el nombre del organigrama o el árbol de trabajo',
+  'import.invalid_bundle_root':
+    'Paquete no válido: la raíz del árbol de trabajo debe tener id, nombre y cargo',
   'import.invalid_bundle_versions': 'Paquete no válido: las versiones deben ser un arreglo',
-  'import.invalid_bundle_version_entry': 'Paquete no válido: cada versión debe tener nombre y árbol',
+  'import.invalid_bundle_version_entry':
+    'Paquete no válido: cada versión debe tener nombre y árbol',
   'import.loading': 'Cargando…',
   'import.drop_or': 'Suelta un archivo o ',
   'import.original_version_name': 'Original',
@@ -454,7 +469,8 @@ const es: Record<string, string> = {
 
   // ─── Column Mapper ─────────────────────────────────────────────────
   'column_mapper.heading': 'Mapear columnas CSV',
-  'column_mapper.description': 'We couldn\'t auto-detect your CSV format. Please map each column below.',
+  'column_mapper.description':
+    "We couldn't auto-detect your CSV format. Please map each column below.",
   'column_mapper.name_column': 'Columna de nombre',
   'column_mapper.title_column': 'Columna de cargo',
   'column_mapper.parent_column_name': 'Reporta a (nombre)',
@@ -480,8 +496,10 @@ const es: Record<string, string> = {
   'column_mapper.select_placeholder': '— Seleccionar —',
   'column_mapper.none_placeholder': '— Ninguno —',
   'column_mapper.error_required': 'Seleccione una columna para Nombre, Cargo y Reporta a.',
-  'column_mapper.error_id_required': 'Al usar referencias "Por ID", la columna de ID debe estar mapeada.',
-  'column_mapper.error_duplicates': 'Cada columna solo puede mapearse a un campo. Elimine los duplicados.',
+  'column_mapper.error_id_required':
+    'Al usar referencias "Por ID", la columna de ID debe estar mapeada.',
+  'column_mapper.error_duplicates':
+    'Cada columna solo puede mapearse a un campo. Elimine los duplicados.',
 
   // ─── Preset Creator ────────────────────────────────────────────────
   'preset_creator.heading': 'Crear preajuste de mapeo',
@@ -502,8 +520,10 @@ const es: Record<string, string> = {
   'preset_creator.cancel': 'Cancelar',
   'preset_creator.save': 'Guardar',
   'preset_creator.error_name_required': 'El nombre del preajuste es obligatorio.',
-  'preset_creator.error_columns_required': 'Las columnas de Nombre, Cargo y Reporta a son obligatorias.',
-  'preset_creator.error_id_required': 'La columna de ID es obligatoria cuando el tipo de referencia es "Por ID".',
+  'preset_creator.error_columns_required':
+    'Las columnas de Nombre, Cargo y Reporta a son obligatorias.',
+  'preset_creator.error_id_required':
+    'La columna de ID es obligatoria cuando el tipo de referencia es "Por ID".',
 
   // ─── Import Editor ─────────────────────────────────────────────────
   'import_editor.preset_heading': 'Preajuste de mapeo',
@@ -614,7 +634,8 @@ const es: Record<string, string> = {
   'settings.save_preset_button': 'Guardar',
   'settings.save_preset_skip': 'No',
   'settings.save_preset_prompt_title': '¿Guardar como preajuste?',
-  'settings.save_preset_prompt_label': 'Su configuración ha cambiado. ¿Desea guardarla como un preajuste reutilizable?',
+  'settings.save_preset_prompt_label':
+    'Su configuración ha cambiado. ¿Desea guardarla como un preajuste reutilizable?',
   'settings.layout_label': 'Disposición',
 
   // ─── Setting Group Titles ──────────────────────────────────────────
@@ -689,23 +710,30 @@ const es: Record<string, string> = {
   'theme.emerald.name': 'Esmeralda',
   'theme.emerald.description': 'Tema verde predeterminado con tarjetas blancas limpias',
   'theme.corporate_blue.name': 'Azul corporativo',
-  'theme.corporate_blue.description': 'Tema profesional en tonos azules para presentaciones de negocios',
+  'theme.corporate_blue.description':
+    'Tema profesional en tonos azules para presentaciones de negocios',
   'theme.forest.name': 'Bosque',
   'theme.forest.description': 'Verdes profundos de bosque que evocan un estilo natural y orgánico',
   'theme.sunset_warm.name': 'Atardecer cálido',
-  'theme.sunset_warm.description': 'Tonos cálidos de ámbar y naranja inspirados en la luz del atardecer',
+  'theme.sunset_warm.description':
+    'Tonos cálidos de ámbar y naranja inspirados en la luz del atardecer',
   'theme.monochrome.name': 'Monocromático',
-  'theme.monochrome.description': 'Paleta limpia en escala de grises que mantiene el enfoque en la estructura',
+  'theme.monochrome.description':
+    'Paleta limpia en escala de grises que mantiene el enfoque en la estructura',
   'theme.midnight.name': 'Medianoche',
-  'theme.midnight.description': 'Colores de modo oscuro con acentos azul claro sobre tarjetas oscuras',
+  'theme.midnight.description':
+    'Colores de modo oscuro con acentos azul claro sobre tarjetas oscuras',
   'theme.pastel.name': 'Pastel',
   'theme.pastel.description': 'Tonos suaves de rosa y púrpura para un aspecto amigable y delicado',
   'theme.high_contrast.name': 'Alto contraste',
-  'theme.high_contrast.description': 'Tema de máxima accesibilidad con bordes gruesos y contrastes marcados',
+  'theme.high_contrast.description':
+    'Tema de máxima accesibilidad con bordes gruesos y contrastes marcados',
   'theme.ocean_teal.name': 'Océano verde azulado',
-  'theme.ocean_teal.description': 'Tema moderno con acentos verde azulado y texto alineado a la izquierda',
+  'theme.ocean_teal.description':
+    'Tema moderno con acentos verde azulado y texto alineado a la izquierda',
   'theme.stone.name': 'Piedra',
-  'theme.stone.description': 'Bordes verdes sobre blanco con contenedores CI grises y conectores azules',
+  'theme.stone.description':
+    'Bordes verdes sobre blanco con contenedores CI grises y conectores azules',
 
   // ─── Category Defaults ─────────────────────────────────────────────
   'category.open_position': 'Posición abierta',
@@ -726,16 +754,20 @@ const es: Record<string, string> = {
   'chart_store.error_no_active': 'No hay organigrama activo',
   'chart_store.error_version_name_empty': 'El nombre de la versión no puede estar vacío',
   'chart_store.error_version_not_found': 'Versión no encontrada: {id}',
-  'chart_store.error_import_invalid_tree': 'El archivo importado contiene datos de árbol no válidos: {detail}',
+  'chart_store.error_import_invalid_tree':
+    'El archivo importado contiene datos de árbol no válidos: {detail}',
 
   // ─── Org Store Validation ──────────────────────────────────────────
   'org_store.error_remove_root': 'No se puede eliminar el nodo raíz',
   'org_store.error_node_not_found': 'Nodo "{id}" no encontrado',
   'org_store.error_parent_not_found': 'Nodo superior "{id}" no encontrado',
-  'org_store.error_reassign_self': 'No se pueden reasignar los subordinados al nodo que se está eliminando',
-  'org_store.error_reassign_descendant': 'No se pueden reasignar los subordinados a un descendiente del nodo que se está eliminando',
+  'org_store.error_reassign_self':
+    'No se pueden reasignar los subordinados al nodo que se está eliminando',
+  'org_store.error_reassign_descendant':
+    'No se pueden reasignar los subordinados a un descendiente del nodo que se está eliminando',
   'org_store.error_dotted_root': 'No se puede establecer línea punteada en el nodo raíz',
-  'org_store.error_dotted_ic': 'No se puede establecer línea punteada en un nodo CI (Colaborador Individual)',
+  'org_store.error_dotted_ic':
+    'No se puede establecer línea punteada en un nodo CI (Colaborador Individual)',
   'org_store.error_move_root': 'No se puede mover el nodo raíz',
   'org_store.error_move_self': 'No se puede mover un nodo debajo de sí mismo',
   'org_store.error_move_descendant': 'No se puede mover un nodo debajo de su propio descendiente',
@@ -747,24 +779,39 @@ const es: Record<string, string> = {
   'org_store.error_title_required': 'Cada nodo debe tener un cargo de tipo cadena',
   'org_store.error_name_too_long': 'Nombre demasiado largo (máx. 500 caracteres) en el nodo "{id}"',
   'org_store.error_title_too_long': 'Cargo demasiado largo (máx. 500 caracteres) en el nodo "{id}"',
-  'org_store.error_invalid_category': 'categoryId no válido en el nodo "{id}": se esperaba una cadena',
-  'org_store.error_category_too_long': 'categoryId demasiado largo (máx. 100 caracteres) en el nodo "{id}"',
-  'org_store.error_invalid_dotted': 'dottedLine no válido en el nodo "{id}": se esperaba un booleano',
-  'org_store.error_invalid_children': 'children no válido en el nodo "{id}": se esperaba un arreglo',
+  'org_store.error_invalid_category':
+    'categoryId no válido en el nodo "{id}": se esperaba una cadena',
+  'org_store.error_category_too_long':
+    'categoryId demasiado largo (máx. 100 caracteres) en el nodo "{id}"',
+  'org_store.error_invalid_dotted':
+    'dottedLine no válido en el nodo "{id}": se esperaba un booleano',
+  'org_store.error_invalid_children':
+    'children no válido en el nodo "{id}": se esperaba un arreglo',
 
   // ─── CSV Parser ────────────────────────────────────────────────────
-  'csv.error_no_name_title': 'Formato CSV no reconocible: no se encontraron las columnas requeridas "name" y "title".',
-  'csv.error_no_parent': 'Formato CSV no reconocible: no se encontró la columna de referencia al superior (parent_id, manager_name o reports_to).',
-  'csv.error_header_only': 'El CSV debe contener una fila de encabezado y al menos una fila de datos.',
-  'csv.error_min_rows_1': 'El CSV debe contener al menos 1 fila de datos (se necesita al menos un nodo raíz).',
+  'csv.error_no_name_title':
+    'Formato CSV no reconocible: no se encontraron las columnas requeridas "name" y "title".',
+  'csv.error_no_parent':
+    'Formato CSV no reconocible: no se encontró la columna de referencia al superior (parent_id, manager_name o reports_to).',
+  'csv.error_header_only':
+    'El CSV debe contener una fila de encabezado y al menos una fila de datos.',
+  'csv.error_min_rows_1':
+    'El CSV debe contener al menos 1 fila de datos (se necesita al menos un nodo raíz).',
   'csv.error_min_rows_2': 'El CSV debe contener al menos 2 filas de datos.',
-  'csv.error_max_nodes': 'El CSV contiene {count} filas de datos, lo cual excede el máximo de {max}. Reduzca el conjunto de datos.',
-  'csv.error_missing_columns': 'Error de mapeo de columnas: las siguientes columnas no se encontraron en los encabezados del CSV: {missing}. Encabezados disponibles: {available}',
-  'csv.error_duplicate_id': 'ID duplicado "{id}": "{name1}" y "{name2}" comparten el mismo identificador.',
-  'csv.error_duplicate_name': 'Nombre duplicado "{name}": dos personas comparten el mismo nombre. Use importación por ID (con una columna de alias único) para distinguirlos.',
-  'csv.error_orphan_id': 'Referencia huérfana: el nodo "{name}" hace referencia al parent_id "{ref}" que no existe.',
-  'csv.error_orphan_name': 'Referencia huérfana: el nodo "{name}" hace referencia al superior "{ref}" que no existe.',
-  'csv.error_no_root': 'No se encontró nodo raíz (cada nodo tiene una referencia a un superior — posible referencia circular).',
+  'csv.error_max_nodes':
+    'El CSV contiene {count} filas de datos, lo cual excede el máximo de {max}. Reduzca el conjunto de datos.',
+  'csv.error_missing_columns':
+    'Error de mapeo de columnas: las siguientes columnas no se encontraron en los encabezados del CSV: {missing}. Encabezados disponibles: {available}',
+  'csv.error_duplicate_id':
+    'ID duplicado "{id}": "{name1}" y "{name2}" comparten el mismo identificador.',
+  'csv.error_duplicate_name':
+    'Nombre duplicado "{name}": dos personas comparten el mismo nombre. Use importación por ID (con una columna de alias único) para distinguirlos.',
+  'csv.error_orphan_id':
+    'Referencia huérfana: el nodo "{name}" hace referencia al parent_id "{ref}" que no existe.',
+  'csv.error_orphan_name':
+    'Referencia huérfana: el nodo "{name}" hace referencia al superior "{ref}" que no existe.',
+  'csv.error_no_root':
+    'No se encontró nodo raíz (cada nodo tiene una referencia a un superior — posible referencia circular).',
   'csv.error_multiple_roots': 'Se detectaron múltiples raíces: {roots}. Solo se permite una raíz.',
   'csv.error_circular': 'Referencia circular: {path}',
 
@@ -777,35 +824,47 @@ const es: Record<string, string> = {
   'help.sample_org_button': '🌳 Cargar organigrama de ejemplo',
   'help.sample_org_aria': 'Cargar un organigrama de ejemplo',
   'help.sample_org_confirm_title': '¿Cargar organigrama de ejemplo?',
-  'help.sample_org_confirm_message': 'Esto reemplazará el organigrama actual con una organización de ejemplo. Puede deshacer esta acción.',
+  'help.sample_org_confirm_message':
+    'Esto reemplazará el organigrama actual con una organización de ejemplo. Puede deshacer esta acción.',
   'help.section_toggle_aria': 'Alternar sección {section}',
 
   // Help: Getting Started
   'help.getting_started.title': 'Primeros pasos',
-  'help.getting_started.pan_zoom': 'El organigrama muestra la jerarquía de su organización. Desplácese arrastrando el lienzo, acerque o aleje con la rueda del ratón.',
-  'help.getting_started.right_click': 'Haga clic derecho en cualquier tarjeta para opciones de editar, agregar, mover o eliminar.',
-  'help.getting_started.sidebar': 'La barra lateral gestiona organigramas y versiones. Use los botones de la barra de herramientas para Configuración (⚙️), Importar (📂) y Exportar (📤).',
+  'help.getting_started.pan_zoom':
+    'El organigrama muestra la jerarquía de su organización. Desplácese arrastrando el lienzo, acerque o aleje con la rueda del ratón.',
+  'help.getting_started.right_click':
+    'Haga clic derecho en cualquier tarjeta para opciones de editar, agregar, mover o eliminar.',
+  'help.getting_started.sidebar':
+    'La barra lateral gestiona organigramas y versiones. Use los botones de la barra de herramientas para Configuración (⚙️), Importar (📂) y Exportar (📤).',
 
   // Help: How the Chart Works
   'help.chart_works.title': 'Cómo funciona el organigrama',
   'help.chart_works.managers_label': 'Gerentes',
-  'help.chart_works.managers_desc': ' — Personas con reportes directos. Conectados por líneas de árbol.',
+  'help.chart_works.managers_desc':
+    ' — Personas con reportes directos. Conectados por líneas de árbol.',
   'help.chart_works.ics_label': 'CI (Colaboradores Individuales)',
-  'help.chart_works.ics_desc': ' — Empleados sin reportes directos. Se muestran en pilas verticales compactas bajo su gerente.',
+  'help.chart_works.ics_desc':
+    ' — Empleados sin reportes directos. Se muestran en pilas verticales compactas bajo su gerente.',
   'help.chart_works.advisors_label': 'Asesores',
-  'help.chart_works.advisors_desc': ' — Personal que reporta directamente a un gerente senior (uno que gestiona a otros gerentes), como un Jefe de Gabinete o Asistente Ejecutivo. Se muestran en un diseño especial de 2 columnas junto a la tarjeta del gerente.',
-  'help.chart_works.auto_detect': 'El organigrama detecta automáticamente estos roles según la jerarquía — no se necesita configuración manual.',
+  'help.chart_works.advisors_desc':
+    ' — Personal que reporta directamente a un gerente senior (uno que gestiona a otros gerentes), como un Jefe de Gabinete o Asistente Ejecutivo. Se muestran en un diseño especial de 2 columnas junto a la tarjeta del gerente.',
+  'help.chart_works.auto_detect':
+    'El organigrama detecta automáticamente estos roles según la jerarquía — no se necesita configuración manual.',
 
   // Help: Toolbar & Sidebar
   'help.sidebar_tabs.title': 'Barra de herramientas y lateral',
   'help.sidebar_tabs.sidebar_label': 'Barra lateral',
-  'help.sidebar_tabs.sidebar_desc': ' — Explorar, crear, renombrar y cambiar entre organigramas. Guardar, ver, comparar y restaurar versiones con nombre.',
+  'help.sidebar_tabs.sidebar_desc':
+    ' — Explorar, crear, renombrar y cambiar entre organigramas. Guardar, ver, comparar y restaurar versiones con nombre.',
   'help.sidebar_tabs.settings_label': 'Configuración (⚙️)',
-  'help.sidebar_tabs.settings_desc': ' — Abre un diálogo para ajustar tamaños de tarjeta, espaciado, colores, tipografía y categorías. Incluye preajustes de tema y vista previa en vivo.',
+  'help.sidebar_tabs.settings_desc':
+    ' — Abre un diálogo para ajustar tamaños de tarjeta, espaciado, colores, tipografía y categorías. Incluye preajustes de tema y vista previa en vivo.',
   'help.sidebar_tabs.import_label': 'Importar (📂)',
-  'help.sidebar_tabs.import_desc': ' — Abre un asistente paso a paso para importar datos desde archivos JSON o CSV, con mapeo de columnas y normalización de texto.',
+  'help.sidebar_tabs.import_desc':
+    ' — Abre un asistente paso a paso para importar datos desde archivos JSON o CSV, con mapeo de columnas y normalización de texto.',
   'help.sidebar_tabs.export_label': 'Exportar (📤)',
-  'help.sidebar_tabs.export_desc': ' — Descarga el organigrama como un archivo PowerPoint editable. Elija qué versiones guardadas incluir.',
+  'help.sidebar_tabs.export_desc':
+    ' — Descarga el organigrama como un archivo PowerPoint editable. Elija qué versiones guardadas incluir.',
 
   // Help: Charts & Versions
   'help.charts_versions.title': 'Organigramas y versiones',
@@ -814,24 +873,31 @@ const es: Record<string, string> = {
   'help.charts_versions.multiple_2': '. Cree, renombre y cambie entre organigramas en la ',
   'help.charts_versions.multiple_tab': 'barra lateral',
   'help.charts_versions.multiple_3': '.',
-  'help.charts_versions.header': 'Pase el cursor sobre el organigrama activo en la barra lateral para acceder a las acciones de Renombrar, Duplicar, Exportar y Eliminar.',
+  'help.charts_versions.header':
+    'Pase el cursor sobre el organigrama activo en la barra lateral para acceder a las acciones de Renombrar, Duplicar, Exportar y Eliminar.',
   'help.charts_versions.save_label': 'Guardar una versión',
-  'help.charts_versions.save_desc': ' — Tome una instantánea con nombre del organigrama actual usando el botón Guardar en la sección Versiones de la barra lateral.',
+  'help.charts_versions.save_desc':
+    ' — Tome una instantánea con nombre del organigrama actual usando el botón Guardar en la sección Versiones de la barra lateral.',
   'help.charts_versions.view_label': 'Ver una versión',
-  'help.charts_versions.view_desc': ' — Abre una vista previa de solo lectura. Haga clic en Restaurar para convertirla en el organigrama de trabajo, o en Cerrar para volver.',
-  'help.charts_versions.unsaved': 'Si tiene cambios sin guardar al cambiar de organigrama o restaurar una versión, se le advertirá primero.',
+  'help.charts_versions.view_desc':
+    ' — Abre una vista previa de solo lectura. Haga clic en Restaurar para convertirla en el organigrama de trabajo, o en Cerrar para volver.',
+  'help.charts_versions.unsaved':
+    'Si tiene cambios sin guardar al cambiar de organigrama o restaurar una versión, se le advertirá primero.',
 
   // Help: Importing Data
   'help.importing.title': 'Importar datos',
   'help.importing.how_1': 'Haga clic en el botón ',
   'help.importing.how_strong': '📂 Importar',
   'help.importing.how_2': ' en la barra de herramientas, o use la paleta de comandos (Ctrl+K).',
-  'help.importing.wizard': 'El asistente de importación lo guía a través de cuatro pasos: elegir un origen, mapear columnas (solo CSV), previsualizar los datos y seleccionar un destino.',
+  'help.importing.wizard':
+    'El asistente de importación lo guía a través de cuatro pasos: elegir un origen, mapear columnas (solo CSV), previsualizar los datos y seleccionar un destino.',
   'help.importing.json_label': 'JSON',
   'help.importing.json_desc': ' — Formato de árbol anidado. Se reconoce automáticamente.',
   'help.importing.csv_label': 'CSV',
-  'help.importing.csv_desc': ' — Tabla plana con columnas de nombre, cargo y superior. El mapeador de columnas permite asociar sus encabezados con los campos requeridos y guardar preajustes.',
-  'help.importing.normalize': 'La normalización de texto (Tipo Título, MAYÚSCULAS, minúsculas) se puede aplicar durante el paso de vista previa.',
+  'help.importing.csv_desc':
+    ' — Tabla plana con columnas de nombre, cargo y superior. El mapeador de columnas permite asociar sus encabezados con los campos requeridos y guardar preajustes.',
+  'help.importing.normalize':
+    'La normalización de texto (Tipo Título, MAYÚSCULAS, minúsculas) se puede aplicar durante el paso de vista previa.',
   'help.importing.limit': 'Máximo 10,000 personas por importación.',
 
   // Help: Chart Interactions
@@ -839,22 +905,29 @@ const es: Record<string, string> = {
   'help.interactions.click_label': 'Clic',
   'help.interactions.click_desc': ' — Seleccionar y resaltar una tarjeta.',
   'help.interactions.right_click_label': 'Clic derecho',
-  'help.interactions.right_click_desc': ' — Menú contextual con Editar, Agregar, Enfocar, Categoría, Punteada/Sólida, Mover y Eliminar.',
+  'help.interactions.right_click_desc':
+    ' — Menú contextual con Editar, Agregar, Enfocar, Categoría, Punteada/Sólida, Mover y Eliminar.',
   'help.interactions.shift_click_label': 'Shift+clic',
-  'help.interactions.shift_click_desc': ' — Selección múltiple de tarjetas, luego clic derecho para Categoría, Mover todos o Eliminar todos en masa.',
+  'help.interactions.shift_click_desc':
+    ' — Selección múltiple de tarjetas, luego clic derecho para Categoría, Mover todos o Eliminar todos en masa.',
   'help.interactions.escape_label': 'Escape',
-  'help.interactions.escape_desc': ' — Cerrar visor de versiones, limpiar búsqueda, salir del modo enfoque, limpiar selección múltiple o deseleccionar (en ese orden de prioridad).',
+  'help.interactions.escape_desc':
+    ' — Cerrar visor de versiones, limpiar búsqueda, salir del modo enfoque, limpiar selección múltiple o deseleccionar (en ese orden de prioridad).',
   'help.interactions.inline_label': 'Edición en línea',
-  'help.interactions.inline_desc': ' — Haga clic derecho en una tarjeta y elija Editar para editar directamente sobre la tarjeta.',
+  'help.interactions.inline_desc':
+    ' — Haga clic derecho en una tarjeta y elija Editar para editar directamente sobre la tarjeta.',
   'help.interactions.search_label': 'Buscar',
-  'help.interactions.search_desc': ' — Escriba en la barra de búsqueda para resaltar personas coincidentes. Las no coincidentes se atenúan.',
+  'help.interactions.search_desc':
+    ' — Escriba en la barra de búsqueda para resaltar personas coincidentes. Las no coincidentes se atenúan.',
 
   // Help: Color Categories
   'help.categories.title': 'Categorías de color',
-  'help.categories.assign_1': 'Asigne una categoría de color a cualquier persona haciendo clic derecho en su tarjeta y eligiendo ',
+  'help.categories.assign_1':
+    'Asigne una categoría de color a cualquier persona haciendo clic derecho en su tarjeta y eligiendo ',
   'help.categories.assign_strong': 'Categoría',
   'help.categories.assign_2': '.',
-  'help.categories.defaults_1': 'Cada organigrama tiene su propio conjunto de categorías. Categorías predeterminadas: ',
+  'help.categories.defaults_1':
+    'Cada organigrama tiene su propio conjunto de categorías. Categorías predeterminadas: ',
   'help.categories.defaults_open': 'Posición abierta',
   'help.categories.defaults_2': ', ',
   'help.categories.defaults_offer': 'Oferta pendiente',
@@ -864,48 +937,61 @@ const es: Record<string, string> = {
   'help.categories.manage_1': 'Agregue, edite o elimine categorías en el diálogo de ',
   'help.categories.manage_strong': 'Configuración',
   'help.categories.manage_2': ' en la pestaña Categorías.',
-  'help.categories.legend': 'Una leyenda de colores aparece en el organigrama cuando hay categorías en uso y se incluye en las exportaciones de PowerPoint.',
+  'help.categories.legend':
+    'Una leyenda de colores aparece en el organigrama cuando hay categorías en uso y se incluye en las exportaciones de PowerPoint.',
 
   // Help: Focus Mode
   'help.focus_mode.title': 'Modo enfoque',
   'help.focus_mode.enter_1': 'Haga clic derecho en cualquier gerente y elija ',
   'help.focus_mode.enter_strong': 'Enfocar',
-  'help.focus_mode.enter_2': ' para ver solo el equipo de esa persona como un organigrama independiente.',
+  'help.focus_mode.enter_2':
+    ' para ver solo el equipo de esa persona como un organigrama independiente.',
   'help.focus_mode.exit_1': 'Presione ',
   'help.focus_mode.exit_kbd': 'Escape',
   'help.focus_mode.exit_2': ' o haga clic en ',
   'help.focus_mode.exit_strong': 'Mostrar organigrama completo',
   'help.focus_mode.exit_3': ' en el banner para volver al organigrama completo.',
-  'help.focus_mode.export': 'La exportación a PowerPoint y las estadísticas de la barra de estado reflejan automáticamente la sub-organización enfocada.',
+  'help.focus_mode.export':
+    'La exportación a PowerPoint y las estadísticas de la barra de estado reflejan automáticamente la sub-organización enfocada.',
 
   // Help: Headcount Badges
   'help.headcount.title': 'Insignias de personal',
-  'help.headcount.enable_1': 'Los gerentes pueden mostrar una insignia con su recuento total de personal (número de personas en su organización). Habilítelo en ',
+  'help.headcount.enable_1':
+    'Los gerentes pueden mostrar una insignia con su recuento total de personal (número de personas en su organización). Habilítelo en ',
   'help.headcount.enable_settings': 'Configuración',
   'help.headcount.enable_2': ' en la pestaña ',
   'help.headcount.enable_strong': 'Insignias',
   'help.headcount.enable_3': '.',
-  'help.headcount.customize': 'La apariencia de la insignia (color, tamaño, radio) se puede personalizar en la misma pestaña Insignias.',
+  'help.headcount.customize':
+    'La apariencia de la insignia (color, tamaño, radio) se puede personalizar en la misma pestaña Insignias.',
 
   // Help: Your Data
   'help.your_data.title': 'Sus datos',
-  'help.your_data.privacy_1': 'Arbol se ejecuta completamente en su navegador. Sus organigramas, versiones y preferencias se almacenan en el almacenamiento de su navegador (IndexedDB y localStorage) y ',
+  'help.your_data.privacy_1':
+    'Arbol se ejecuta completamente en su navegador. Sus organigramas, versiones y preferencias se almacenan en el almacenamiento de su navegador (IndexedDB y localStorage) y ',
   'help.your_data.privacy_strong': 'nunca salen de su dispositivo',
   'help.your_data.privacy_2': '.',
-  'help.your_data.no_server': 'No hay servidor, ni base de datos, ni rastreo, ni cuenta requerida. Sus datos permanecen en su máquina​–​nadie más puede verlos.',
+  'help.your_data.no_server':
+    'No hay servidor, ni base de datos, ni rastreo, ni cuenta requerida. Sus datos permanecen en su máquina​–​nadie más puede verlos.',
 
   // Help: Settings & Persistence
   'help.settings.title': 'Configuración',
-  'help.settings.auto_save': 'Toda la configuración visual se guarda automáticamente en su navegador y se restaura en la siguiente visita.',
-  'help.settings.modal': 'Abra Configuración (botón ⚙️ o Ctrl+,) para acceder a 10 pestañas: Preajustes, Disposición, Tipografía, Tarjetas, Conectores, Opciones CI, Asesores, Insignias, Categorías y Respaldo.',
-  'help.settings.presets': 'Los preajustes de tema aplican un conjunto completo de colores y espaciado con un solo clic. También puede guardar sus propios preajustes personalizados.',
-  'help.settings.preview': 'Una vista previa en vivo a la derecha muestra los cambios mientras ajusta la configuración.',
+  'help.settings.auto_save':
+    'Toda la configuración visual se guarda automáticamente en su navegador y se restaura en la siguiente visita.',
+  'help.settings.modal':
+    'Abra Configuración (botón ⚙️ o Ctrl+,) para acceder a 10 pestañas: Preajustes, Disposición, Tipografía, Tarjetas, Conectores, Opciones CI, Asesores, Insignias, Categorías y Respaldo.',
+  'help.settings.presets':
+    'Los preajustes de tema aplican un conjunto completo de colores y espaciado con un solo clic. También puede guardar sus propios preajustes personalizados.',
+  'help.settings.preview':
+    'Una vista previa en vivo a la derecha muestra los cambios mientras ajusta la configuración.',
   'help.settings.backup_1': 'Utilice ',
   'help.settings.backup_strong': 'Crear respaldo',
-  'help.settings.backup_2': ' en la pestaña Respaldo para guardar todos sus organigramas, versiones y configuración en un solo archivo.',
+  'help.settings.backup_2':
+    ' en la pestaña Respaldo para guardar todos sus organigramas, versiones y configuración en un solo archivo.',
   'help.settings.restore_1': 'Utilice ',
   'help.settings.restore_strong': 'Restaurar',
-  'help.settings.restore_2': ' para cargar un respaldo. Puede elegir reemplazar todos los datos o combinarlos con sus organigramas existentes.',
+  'help.settings.restore_2':
+    ' para cargar un respaldo. Puede elegir reemplazar todos los datos o combinarlos con sus organigramas existentes.',
 
   // Help: Keyboard Shortcuts
   'help.shortcuts.title': 'Atajos de teclado',
@@ -926,14 +1012,18 @@ const es: Record<string, string> = {
   // Help: Exporting
   'help.exporting.title': 'Exportar',
   'help.exporting.pptx_label': 'Exportar PPTX',
-  'help.exporting.pptx_desc': ' — Descarga el organigrama como un archivo PowerPoint editable con formas nativas y texto.',
-  'help.exporting.versions': 'El diálogo de exportación permite seleccionar qué versiones guardadas incluir — cada versión se convierte en una diapositiva separada.',
-  'help.exporting.scale': 'La exportación se escala automáticamente para ajustarse a una diapositiva panorámica.',
+  'help.exporting.pptx_desc':
+    ' — Descarga el organigrama como un archivo PowerPoint editable con formas nativas y texto.',
+  'help.exporting.versions':
+    'El diálogo de exportación permite seleccionar qué versiones guardadas incluir — cada versión se convierte en una diapositiva separada.',
+  'help.exporting.scale':
+    'La exportación se escala automáticamente para ajustarse a una diapositiva panorámica.',
 
   // Help: Links
   'help.links.title': 'Enlaces',
   'help.links.built_with': '✦ Creado con Arbol — https://github.com/pedrofuentes/arbol',
-  'help.links.report_bugs': 'Reportar errores y solicitar funciones — https://github.com/pedrofuentes/arbol/issues',
+  'help.links.report_bugs':
+    'Reportar errores y solicitar funciones — https://github.com/pedrofuentes/arbol/issues',
 
   // ─── Comparison Banner ─────────────────────────────────────────────
   'comparison.working_tree': 'Árbol de trabajo',
@@ -949,7 +1039,8 @@ const es: Record<string, string> = {
 
   // ─── Import Wizard Steps ──────────────────────────────────────────
   'import_wizard.source_title': 'Elija su origen de datos',
-  'import_wizard.source_desc': 'Suba un archivo o pegue datos directamente. Soportamos formatos CSV, JSON y Excel.',
+  'import_wizard.source_desc':
+    'Suba un archivo o pegue datos directamente. Soportamos formatos CSV, JSON y Excel.',
   'import_wizard.drop_text': 'Suelte un archivo aquí o haga clic para examinar',
   'import_wizard.drop_hint': 'CSV, JSON o XLSX · Máx. 10,000 personas',
   'import_wizard.file_aria': 'Elegir archivo para importar',
@@ -958,9 +1049,11 @@ const es: Record<string, string> = {
   'import_wizard.paste_aria': 'Pegar datos de importación',
   'import_wizard.mapping_json': '✓ Formato JSON detectado — no se necesita mapeo de columnas.',
   'import_wizard.mapping_csv': 'Mapee sus columnas CSV a los campos correctos.',
-  'import_wizard.mapping_verify': 'Verifique el mapeo de columnas a continuación, luego haga clic en Siguiente.',
+  'import_wizard.mapping_verify':
+    'Verifique el mapeo de columnas a continuación, luego haga clic en Siguiente.',
   'import_wizard.preset_matched': '✓ Preajuste guardado encontrado: "{name}"',
-  'import_wizard.save_preset_prompt': '¿Guardar este mapeo de columnas como preajuste para futuras importaciones?',
+  'import_wizard.save_preset_prompt':
+    '¿Guardar este mapeo de columnas como preajuste para futuras importaciones?',
   'import_wizard.save_preset_label': 'Nombre del preajuste',
   'import_wizard.save_preset_placeholder': 'ej. Formato de exportación RRHH',
   'import_wizard.preview_success': '✓ {count} personas analizadas desde {format}',
@@ -992,9 +1085,12 @@ const es: Record<string, string> = {
   'settings.desc.node_height': 'Alto de la tarjeta de cada persona',
   'settings.desc.horizontal_spacing': 'Espacio mínimo entre tarjetas del mismo nivel',
   'settings.desc.branch_spacing': 'Espacio entre ramas separadas del árbol',
-  'settings.desc.top_vertical_spacing': 'Espacio desde la tarjeta del gerente hasta la línea conectora inferior',
-  'settings.desc.bottom_vertical_spacing': 'Espacio desde la línea conectora hasta las tarjetas subordinadas',
-  'settings.desc.ic_node_width': 'Ancho de las tarjetas de colaboradores individuales en la vista apilada',
+  'settings.desc.top_vertical_spacing':
+    'Espacio desde la tarjeta del gerente hasta la línea conectora inferior',
+  'settings.desc.bottom_vertical_spacing':
+    'Espacio desde la línea conectora hasta las tarjetas subordinadas',
+  'settings.desc.ic_node_width':
+    'Ancho de las tarjetas de colaboradores individuales en la vista apilada',
   'settings.desc.ic_gap': 'Espacio vertical entre tarjetas CI apiladas',
   'settings.desc.ic_container_padding': 'Relleno alrededor del contenedor del grupo CI',
   'settings.desc.ic_container_fill': 'Color de fondo del grupo CI',
@@ -1002,24 +1098,30 @@ const es: Record<string, string> = {
   'settings.desc.advisor_top_gap': 'Espacio sobre las tarjetas de asesores',
   'settings.desc.advisor_bottom_gap': 'Espacio debajo de las tarjetas de asesores',
   'settings.desc.advisor_row_gap': 'Espacio vertical entre filas de tarjetas de asesores',
-  'settings.desc.advisor_center_gap': 'Espacio horizontal entre columnas izquierda y derecha de asesores',
+  'settings.desc.advisor_center_gap':
+    'Espacio horizontal entre columnas izquierda y derecha de asesores',
   'settings.desc.name_font_size': 'Tamaño de fuente del nombre de la persona en cada tarjeta',
   'settings.desc.title_font_size': 'Tamaño de fuente del cargo en cada tarjeta',
-  'settings.desc.text_padding_top': 'Espacio desde la parte superior de la tarjeta hasta la primera línea de texto',
+  'settings.desc.text_padding_top':
+    'Espacio desde la parte superior de la tarjeta hasta la primera línea de texto',
   'settings.desc.text_gap': 'Espacio entre las líneas de texto de nombre y cargo',
   'settings.desc.text_alignment': 'Cómo se alinea el texto dentro de cada tarjeta',
-  'settings.desc.font_family': 'Fuente usada para todo el texto del organigrama (compatible con PowerPoint)',
-  'settings.desc.text_padding_horizontal': 'Relleno izquierdo/derecho del texto cuando está alineado a izquierda o derecha',
+  'settings.desc.font_family':
+    'Fuente usada para todo el texto del organigrama (compatible con PowerPoint)',
+  'settings.desc.text_padding_horizontal':
+    'Relleno izquierdo/derecho del texto cuando está alineado a izquierda o derecha',
   'settings.desc.name_color': 'Color del texto de nombres en las tarjetas',
   'settings.desc.title_color': 'Color del texto de cargos en las tarjetas',
   'settings.desc.link_width': 'Grosor de las líneas conectoras entre tarjetas',
   'settings.desc.link_color': 'Color de las líneas conectoras',
-  'settings.desc.dotted_line_pattern': 'Patrón de guiones para líneas de reporte punteadas (ej. "6,4")',
+  'settings.desc.dotted_line_pattern':
+    'Patrón de guiones para líneas de reporte punteadas (ej. "6,4")',
   'settings.desc.card_stroke_width': 'Grosor del borde de las tarjetas',
   'settings.desc.card_stroke': 'Color del borde de las tarjetas',
   'settings.desc.card_fill': 'Color de fondo de las tarjetas',
   'settings.desc.card_border_radius': 'Redondeo de esquinas de las tarjetas',
-  'settings.desc.show_headcount': 'Mostrar una insignia en las tarjetas de gerentes con el recuento total de reportes',
+  'settings.desc.show_headcount':
+    'Mostrar una insignia en las tarjetas de gerentes con el recuento total de reportes',
   'settings.desc.badge_font_size': 'Tamaño de fuente del número en la insignia de personal',
   'settings.desc.badge_height': 'Alto de la insignia de personal',
   'settings.desc.badge_radius': 'Redondeo de esquinas de la insignia de personal',
@@ -1034,20 +1136,32 @@ const es: Record<string, string> = {
   'settings.desc.legend_rows': 'Número de filas para la leyenda de categorías (0 = auto-ajuste)',
 
   // ─── Settings: Section Descriptions ─────────────────────────────────
-  'settings.section_desc.presets': 'Elija un tema visual o guarde su configuración actual como un preajuste personalizado.',
-  'settings.section_desc.categories': 'Defina categorías de color para resaltar roles especiales como posiciones abiertas u ofertas pendientes.',
-  'settings.section_desc.card_dimensions': 'Controle el tamaño de la tarjeta de cada persona en el organigrama.',
+  'settings.section_desc.presets':
+    'Elija un tema visual o guarde su configuración actual como un preajuste personalizado.',
+  'settings.section_desc.categories':
+    'Defina categorías de color para resaltar roles especiales como posiciones abiertas u ofertas pendientes.',
+  'settings.section_desc.card_dimensions':
+    'Controle el tamaño de la tarjeta de cada persona en el organigrama.',
   'settings.section_desc.tree_spacing': 'Ajuste los espacios entre tarjetas y ramas del árbol.',
-  'settings.section_desc.ic_options': 'Configure cómo se muestran los colaboradores individuales en grupos apilados.',
-  'settings.section_desc.advisor_options': 'Controle el espaciado de los nodos de asesores junto a los gerentes.',
-  'settings.section_desc.typography': 'Personalice fuentes, tamaños, colores y alineación del texto en las tarjetas.',
-  'settings.section_desc.link_style': 'Estilice las líneas conectoras entre tarjetas del organigrama.',
-  'settings.section_desc.card_style': 'Personalice bordes, color de fondo y redondeo de esquinas de las tarjetas.',
-  'settings.section_desc.headcount_badge': 'Muestre y estilice una insignia de personal en las tarjetas de gerentes.',
-  'settings.section_desc.level_badge': 'Muestre y estilice una insignia de nivel en todas las tarjetas.',
-  'settings.section_desc.categories_legend': 'Configure cómo aparece la leyenda de categorías de color en el organigrama.',
+  'settings.section_desc.ic_options':
+    'Configure cómo se muestran los colaboradores individuales en grupos apilados.',
+  'settings.section_desc.advisor_options':
+    'Controle el espaciado de los nodos de asesores junto a los gerentes.',
+  'settings.section_desc.typography':
+    'Personalice fuentes, tamaños, colores y alineación del texto en las tarjetas.',
+  'settings.section_desc.link_style':
+    'Estilice las líneas conectoras entre tarjetas del organigrama.',
+  'settings.section_desc.card_style':
+    'Personalice bordes, color de fondo y redondeo de esquinas de las tarjetas.',
+  'settings.section_desc.headcount_badge':
+    'Muestre y estilice una insignia de personal en las tarjetas de gerentes.',
+  'settings.section_desc.level_badge':
+    'Muestre y estilice una insignia de nivel en todas las tarjetas.',
+  'settings.section_desc.categories_legend':
+    'Configure cómo aparece la leyenda de categorías de color en el organigrama.',
   'settings.section_desc.settings_io': 'Exporte o importe su configuración como un archivo.',
-  'settings.section_desc.backup_restore': 'Cree respaldos completos de todos los organigramas, versiones y configuración.',
+  'settings.section_desc.backup_restore':
+    'Cree respaldos completos de todos los organigramas, versiones y configuración.',
 
   // ─── Settings: Layout Preset Descriptions ───────────────────────────
   'settings.layout_compact_desc': 'Espaciado ajustado para organizaciones grandes',
@@ -1070,7 +1184,8 @@ const es: Record<string, string> = {
   // ─── Settings: Category Enhancements ────────────────────────────────
   'settings.category_text_colors': 'Colores de texto:',
   'settings.category_confirm_delete': '¿Eliminar "{label}"?',
-  'settings.category_confirm_delete_message': 'Las personas que usan esta categoría volverán al color de tarjeta predeterminado.',
+  'settings.category_confirm_delete_message':
+    'Las personas que usan esta categoría volverán al color de tarjeta predeterminado.',
   'settings.category_preview_name': 'Nombre',
   'settings.category_preview_title': 'Cargo',
 
@@ -1101,9 +1216,11 @@ const es: Record<string, string> = {
   'export_dialog.cancel': 'Cancelar',
   'export_dialog.export': 'Exportar',
   'restore_dialog.title': 'Restaurar versión',
-  'restore_dialog.summary': '{chartCount} organigrama(s), {versionCount} versión(es) · Creado {backupDate} · v{appVersion}',
+  'restore_dialog.summary':
+    '{chartCount} organigrama(s), {versionCount} versión(es) · Creado {backupDate} · v{appVersion}',
   'restore_dialog.how': '¿Cómo desea restaurar?',
-  'restore_dialog.replace_all': '🔄 Reemplazar todo — borrar datos actuales y restaurar desde respaldo',
+  'restore_dialog.replace_all':
+    '🔄 Reemplazar todo — borrar datos actuales y restaurar desde respaldo',
   'restore_dialog.merge': '➕ Combinar — agregar organigramas nuevos, mantener los existentes',
   'restore_dialog.cancel': 'Cancelar',
   'comparison.dim_on': 'Atenuación: Sí',
@@ -1134,7 +1251,8 @@ const es: Record<string, string> = {
   'settings_modal.tab.level_mapping': 'Mapeo de niveles',
   'settings_modal.tab.backup': 'Respaldo',
   'utilities.heading': 'Normalización de texto',
-  'utilities.desc': 'Normalice el formato de texto de todos los nombres y cargos en el organigrama actual.',
+  'utilities.desc':
+    'Normalice el formato de texto de todos los nombres y cargos en el organigrama actual.',
   'utilities.name_format': 'Formato de nombre',
   'utilities.title_format': 'Formato de cargo',
   'utilities.apply_btn': 'Aplicar al organigrama',
@@ -1147,17 +1265,26 @@ const es: Record<string, string> = {
   'backup.backup_failed': 'Error al crear respaldo: {message}',
   'backup.restore_btn': '📂 Restaurar',
   'backup.replace_title': 'Reemplazar todos los datos',
-  'backup.replace_message': 'Esto reemplazará permanentemente todos los organigramas, versiones y configuraciones existentes con los datos del respaldo. Se ha descargado un respaldo de sus datos actuales.\n\n¿Continuar?',
+  'backup.replace_message':
+    'Esto reemplazará permanentemente todos los organigramas, versiones y configuraciones existentes con los datos del respaldo. Se ha descargado un respaldo de sus datos actuales.\n\n¿Continuar?',
+  'backup.replace_message_no_backup':
+    'Esto reemplazará permanentemente todos los organigramas, versiones y configuraciones existentes con los datos del respaldo. No se creó un respaldo de sus datos actuales.\n\n¿Continuar?',
   'backup.replace_confirm': 'Reemplazar todo',
   'backup.merge_title': 'Combinación completa',
-  'backup.merge_message': 'Se agregaron {chartsAdded} organigrama(s) y {versionsAdded} versión(es). Se omitieron {chartsSkipped} organigrama(s) que ya existían.\n\nLa página se recargará para aplicar los cambios.',
+  'backup.merge_message':
+    'Se agregaron {chartsAdded} organigrama(s) y {versionsAdded} versión(es). Se omitieron {chartsSkipped} organigrama(s) que ya existían.\n\nLa página se recargará para aplicar los cambios.',
   'backup.merge_confirm': 'OK',
   'backup.restore_failed': 'Error al restaurar: {message}',
   'backup.clear_btn': '🗑 Borrar todos los datos',
   'backup.clear_aria': 'Borrar todos los datos locales',
   'backup.clear_title': 'Borrar todos los datos',
-  'backup.clear_message': 'Esto eliminará permanentemente todos sus organigramas, versiones, configuraciones, temas y preferencias. Esta acción no se puede deshacer.\n\n¿Está seguro?',
+  'backup.clear_message':
+    'Esto eliminará permanentemente todos sus organigramas, versiones, configuraciones, temas y preferencias. Esta acción no se puede deshacer.\n\n¿Está seguro?',
   'backup.clear_confirm': 'Borrar todo',
+  'backup.clear_no_backup_title': 'Error al crear respaldo',
+  'backup.clear_no_backup_message':
+    'No se pudo crear un respaldo automático. Si continúa, sus datos se eliminarán permanentemente sin posibilidad de recuperación.\n\n¿Está seguro de que desea continuar sin respaldo?',
+  'backup.clear_no_backup_confirm': 'Continuar sin respaldo',
   'settings_io.export_btn': '\ud83d\udcbe Export',
   'settings_io.import_btn': '\ud83d\udcc2 Import',
   'settings_io.file_too_large': 'Archivo de configuración demasiado grande (máx. 1MB).',
@@ -1176,16 +1303,21 @@ const es: Record<string, string> = {
   'export.default_filename': 'organigrama',
   'app.fatal_error': 'Error al iniciar Arbol',
   'app.unexpected_error': 'Ocurrió un error inesperado',
-  'app.refresh_hint': 'Intenta recargar la página. Si el problema persiste, borra los datos del navegador para este sitio.',
+  'app.refresh_hint':
+    'Intenta recargar la página. Si el problema persiste, borra los datos del navegador para este sitio.',
 
   // ─── Help & Docs ──────────────────────────────────────────────────
-  'column_mapper.parent_ref_help': 'By Name matches the parent column to people\'s names. By ID matches a unique identifier.',
+  'column_mapper.parent_ref_help':
+    "By Name matches the parent column to people's names. By ID matches a unique identifier.",
   'footer.ics_tooltip': 'Individual Contributors \u2014 employees without direct reports',
   'help.comparison.title': 'Comparación de versiones',
-  'help.comparison.desc': 'Use la vista de comparación lado a lado para ver qué cambió entre dos versiones del organigrama.',
+  'help.comparison.desc':
+    'Use la vista de comparación lado a lado para ver qué cambió entre dos versiones del organigrama.',
   'help.interactions.dotted_label': 'Líneas punteadas',
-  'help.interactions.dotted_desc': ' \u2014 Toggle any link to a dotted line via right-click \u2192 Dotted/Solid. Useful for indicating temporary or informal reporting relationships.',
-  'export_dialog.versions_hint': 'Seleccione qué versiones guardadas incluir como diapositivas adicionales.',
+  'help.interactions.dotted_desc':
+    ' \u2014 Toggle any link to a dotted line via right-click \u2192 Dotted/Solid. Useful for indicating temporary or informal reporting relationships.',
+  'export_dialog.versions_hint':
+    'Seleccione qué versiones guardadas incluir como diapositivas adicionales.',
   'export.format_label': 'Formato',
   'export.format_pptx': 'PowerPoint (.pptx)',
   'export.format_svg': 'Imagen SVG (.svg)',
@@ -1198,12 +1330,14 @@ const es: Record<string, string> = {
   'export.exported_png': 'Exportado como PNG',
   // ─── Level Mapping ────────────────────────────────────────────────
   'settings.group.level_mapping': 'Mapeo de niveles',
-  'settings.section_desc.level_mapping': 'Define cómo los valores de nivel se muestran en las tarjetas.',
+  'settings.section_desc.level_mapping':
+    'Define cómo los valores de nivel se muestran en las tarjetas.',
   'settings.level_mapping_section': 'Mapeo de niveles',
   'settings.label.display_mode': 'Visualización de título',
   'settings.label.display_mode_original': 'Título original',
   'settings.label.display_mode_mapped': 'Título mapeado',
-  'settings.desc.display_mode': 'Cuando está en Mapeado, el título en las tarjetas se reemplaza con el título mapeado para ese nivel.',
+  'settings.desc.display_mode':
+    'Cuando está en Mapeado, el título en las tarjetas se reemplaza con el título mapeado para ese nivel.',
   'settings.label.add_mapping': 'Agregar mapeo',
   'settings.label.raw_level': 'Nivel original',
   'settings.label.display_title': 'Título de visualización',

--- a/src/store/backup-manager.ts
+++ b/src/store/backup-manager.ts
@@ -70,7 +70,10 @@ function safeJsonParse(raw: string | null): unknown | null {
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
-export async function createBackup(db: ChartDB, storage: IStorage = browserStorage): Promise<ArbolBackup> {
+export async function createBackup(
+  db: ChartDB,
+  storage: IStorage = browserStorage,
+): Promise<ArbolBackup> {
   const charts = await db.getAllCharts();
 
   const versions: VersionRecord[] = [];
@@ -160,36 +163,114 @@ export function getBackupSummary(backup: ArbolBackup): BackupSummary {
   };
 }
 
-export async function restoreFullReplace(db: ChartDB, backup: ArbolBackup, storage: IStorage = browserStorage): Promise<void> {
-  // Clear localStorage
-  for (const key of ALL_ARBOL_LS_KEYS) {
-    storage.removeItem(key);
-  }
-
-  // Delete all existing charts (this cascades to versions)
-  const existing = await db.getAllCharts();
-  for (const chart of existing) {
-    await db.deleteChart(chart.id);
-  }
-
-  // Write backup charts
+export async function restoreFullReplace(
+  db: ChartDB,
+  backup: ArbolBackup,
+  storage: IStorage = browserStorage,
+): Promise<void> {
+  // Stage 1: Validate all backup data before any destructive operations
+  const validChartIds = new Set<string>();
+  const validCharts: ChartRecord[] = [];
   for (const chart of backup.data.charts) {
     try {
       validateTree(chart.workingTree);
+      validCharts.push(chart);
+      validChartIds.add(chart.id);
     } catch {
       console.warn(`Backup restore: skipping chart "${chart.name}" (${chart.id}) — invalid tree`);
-      continue;
     }
-    await db.putChart(chart);
   }
 
-  // Write backup versions
+  // Filter versions to only those belonging to valid charts
+  const validVersions: VersionRecord[] = [];
   for (const version of backup.data.versions) {
-    await db.putVersion(version);
+    if (!validChartIds.has(version.chartId)) continue;
+    try {
+      validateTree(version.tree);
+      validVersions.push(version);
+    } catch {
+      console.warn(
+        `Backup restore: skipping version "${version.name}" (${version.id}) — invalid tree`,
+      );
+    }
   }
 
-  // Restore localStorage
-  restoreLocalStorage(backup, storage);
+  // Stage 2: Snapshot existing data for rollback
+  const existingCharts = await db.getAllCharts();
+  const existingVersions: VersionRecord[] = [];
+  for (const chart of existingCharts) {
+    const versions = await db.getVersionsByChart(chart.id);
+    existingVersions.push(...versions);
+  }
+  const existingLSValues: Record<string, string | null> = {};
+  for (const key of ALL_ARBOL_LS_KEYS) {
+    existingLSValues[key] = storage.getItem(key);
+  }
+
+  // Stage 3: Clear existing data, write backup, restore localStorage — all rollback-protected
+  const writtenChartIds: string[] = [];
+  const writtenVersionIds: string[] = [];
+  try {
+    for (const key of ALL_ARBOL_LS_KEYS) {
+      storage.removeItem(key);
+    }
+    for (const chart of existingCharts) {
+      await db.deleteChart(chart.id);
+    }
+
+    for (const chart of validCharts) {
+      await db.putChart(chart);
+      writtenChartIds.push(chart.id);
+    }
+    for (const version of validVersions) {
+      await db.putVersion(version);
+      writtenVersionIds.push(version.id);
+    }
+
+    restoreLocalStorage(backup, storage);
+  } catch (error) {
+    // Best-effort rollback: attempt all recovery steps, never abort mid-recovery
+    for (const id of writtenVersionIds) {
+      try {
+        await db.deleteVersion(id);
+      } catch {
+        /* best-effort */
+      }
+    }
+    for (const id of writtenChartIds) {
+      try {
+        await db.deleteChart(id);
+      } catch {
+        /* best-effort */
+      }
+    }
+    for (const chart of existingCharts) {
+      try {
+        await db.putChart(chart);
+      } catch {
+        /* best-effort */
+      }
+    }
+    for (const version of existingVersions) {
+      try {
+        await db.putVersion(version);
+      } catch {
+        /* best-effort */
+      }
+    }
+    for (const [key, value] of Object.entries(existingLSValues)) {
+      try {
+        if (value !== null) {
+          storage.setItem(key, value);
+        } else {
+          storage.removeItem(key);
+        }
+      } catch {
+        /* best-effort */
+      }
+    }
+    throw error;
+  }
 }
 
 export async function restoreMerge(db: ChartDB, backup: ArbolBackup): Promise<MergeResult> {
@@ -218,6 +299,14 @@ export async function restoreMerge(db: ChartDB, backup: ArbolBackup): Promise<Me
     // Restore versions for this newly-added chart
     const chartVersions = backup.data.versions.filter((v) => v.chartId === chart.id);
     for (const version of chartVersions) {
+      try {
+        validateTree(version.tree);
+      } catch {
+        console.warn(
+          `Backup merge: skipping version "${version.name}" (${version.id}) — invalid tree`,
+        );
+        continue;
+      }
       await db.putVersion(version);
       result.versionsAdded++;
     }

--- a/tests/editor/settings/backup-panel.test.ts
+++ b/tests/editor/settings/backup-panel.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, type Mock } from 'vitest';
+import { setLocale } from '../../../src/i18n';
+import en from '../../../src/i18n/en';
+import { BackupPanel, type BackupPanelDeps } from '../../../src/editor/settings/backup-panel';
+import type { ChartDB } from '../../../src/store/chart-db';
+import type { IStorage } from '../../../src/utils/storage';
+
+// ── Mock modules ────────────────────────────────────────────────────────────
+
+vi.mock('../../../src/store/backup-manager', () => ({
+  createBackup: vi.fn(),
+  downloadBackup: vi.fn(),
+  readBackupFile: vi.fn(),
+  restoreFullReplace: vi.fn(),
+  restoreMerge: vi.fn(),
+  getBackupSummary: vi.fn(),
+}));
+
+vi.mock('../../../src/ui/confirm-dialog', () => ({
+  showConfirmDialog: vi.fn(),
+}));
+
+vi.mock('../../../src/ui/restore-dialog', () => ({
+  showRestoreStrategyDialog: vi.fn(),
+}));
+
+vi.mock('../../../src/ui/toast', () => ({
+  showToast: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/file-type', () => ({
+  detectArbolFileType: vi.fn(() => 'backup'),
+}));
+
+import { createBackup } from '../../../src/store/backup-manager';
+import { showConfirmDialog } from '../../../src/ui/confirm-dialog';
+
+beforeAll(() => {
+  setLocale('en', en);
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function createStorage(): IStorage {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      Object.keys(store).forEach((k) => delete store[k]);
+    }),
+  };
+}
+
+function createMockChartDB(): ChartDB {
+  return {
+    getAllCharts: vi.fn(async () => []),
+    getChart: vi.fn(),
+    putChart: vi.fn(),
+    deleteChart: vi.fn(),
+    getVersionsByChart: vi.fn(async () => []),
+    putVersion: vi.fn(),
+    deleteVersion: vi.fn(),
+    isChartNameTaken: vi.fn(async () => false),
+    putVersionsBatch: vi.fn(),
+  } as unknown as ChartDB;
+}
+
+function buildPanel(): { panel: BackupPanel; element: HTMLElement; deps: BackupPanelDeps } {
+  const deps: BackupPanelDeps = {
+    chartDB: createMockChartDB(),
+    storage: createStorage(),
+  };
+  const panel = new BackupPanel(deps);
+  const element = panel.build();
+  return { panel, element, deps };
+}
+
+function getClearButton(element: HTMLElement): HTMLButtonElement {
+  const buttons = element.querySelectorAll('button');
+  for (const btn of buttons) {
+    if (btn.getAttribute('aria-label')?.includes('Clear') || btn.getAttribute('aria-label')?.includes('clear')) {
+      return btn;
+    }
+  }
+  throw new Error('Clear button not found');
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('BackupPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('clear all data — backup failure path', () => {
+    it('shows a warning confirmation when auto-backup fails before clearing', async () => {
+      const { element } = buildPanel();
+      const clearBtn = getClearButton(element);
+
+      // Make createBackup fail
+      (createBackup as Mock).mockRejectedValueOnce(new Error('Backup creation failed'));
+
+      // The first confirm dialog (warning about no backup) should block
+      // unless user explicitly acknowledges. We simulate the user declining.
+      (showConfirmDialog as Mock).mockResolvedValueOnce(false);
+
+      clearBtn.click();
+      await vi.waitFor(() => {
+        expect(showConfirmDialog).toHaveBeenCalled();
+      });
+
+      // Should have been called with a message indicating backup failed
+      const firstCall = (showConfirmDialog as Mock).mock.calls[0][0];
+      expect(firstCall.danger).toBe(true);
+      expect(firstCall.message).toMatch(/backup|failed|no backup/i);
+    });
+
+    it('does not proceed to delete when user declines after backup failure warning', async () => {
+      const { element, deps } = buildPanel();
+      const clearBtn = getClearButton(element);
+
+      (createBackup as Mock).mockRejectedValueOnce(new Error('fail'));
+      // User declines the warning about no backup
+      (showConfirmDialog as Mock).mockResolvedValueOnce(false);
+
+      clearBtn.click();
+      await vi.waitFor(() => {
+        expect(showConfirmDialog).toHaveBeenCalled();
+      });
+
+      // Storage should NOT have been cleared
+      expect(deps.storage.removeItem).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/editor/settings/backup-panel.test.ts
+++ b/tests/editor/settings/backup-panel.test.ts
@@ -32,8 +32,14 @@ vi.mock('../../../src/utils/file-type', () => ({
   detectArbolFileType: vi.fn(() => 'backup'),
 }));
 
-import { createBackup } from '../../../src/store/backup-manager';
+import {
+  createBackup,
+  readBackupFile,
+  getBackupSummary,
+  restoreFullReplace,
+} from '../../../src/store/backup-manager';
 import { showConfirmDialog } from '../../../src/ui/confirm-dialog';
+import { showRestoreStrategyDialog } from '../../../src/ui/restore-dialog';
 
 beforeAll(() => {
   setLocale('en', en);
@@ -84,7 +90,10 @@ function buildPanel(): { panel: BackupPanel; element: HTMLElement; deps: BackupP
 function getClearButton(element: HTMLElement): HTMLButtonElement {
   const buttons = element.querySelectorAll('button');
   for (const btn of buttons) {
-    if (btn.getAttribute('aria-label')?.includes('Clear') || btn.getAttribute('aria-label')?.includes('clear')) {
+    if (
+      btn.getAttribute('aria-label')?.includes('Clear') ||
+      btn.getAttribute('aria-label')?.includes('clear')
+    ) {
       return btn;
     }
   }
@@ -134,8 +143,133 @@ describe('BackupPanel', () => {
         expect(showConfirmDialog).toHaveBeenCalled();
       });
 
-      // Storage should NOT have been cleared
+      // No destructive operations should have been invoked
       expect(deps.storage.removeItem).not.toHaveBeenCalled();
+      // Only the warning dialog, not the actual clear confirmation
+      expect(showConfirmDialog).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('restore replace — backup failure path', () => {
+    function getRestoreButton(element: HTMLElement): HTMLButtonElement {
+      const buttons = element.querySelectorAll('button');
+      for (const btn of buttons) {
+        if (btn.textContent?.includes('Restore')) return btn;
+      }
+      throw new Error('Restore button not found');
+    }
+
+    function setupFileInputCapture(): {
+      getInput: () => HTMLInputElement | null;
+      cleanup: () => void;
+    } {
+      let capturedInput: HTMLInputElement | null = null;
+      const origClick = HTMLInputElement.prototype.click;
+      HTMLInputElement.prototype.click = function (this: HTMLInputElement) {
+        if (this.type === 'file') {
+          capturedInput = this;
+        } else {
+          origClick.call(this);
+        }
+      };
+      return {
+        getInput: () => capturedInput,
+        cleanup: () => {
+          HTMLInputElement.prototype.click = origClick;
+        },
+      };
+    }
+
+    function triggerFileChange(input: HTMLInputElement, fileData: unknown): void {
+      const json = JSON.stringify(fileData);
+      const file = new File([json], 'backup.json', { type: 'application/json' });
+      Object.defineProperty(input, 'files', { value: [file], configurable: true });
+      input.dispatchEvent(new Event('change'));
+    }
+
+    const validBackup = {
+      formatVersion: 1,
+      appVersion: '1.0.0',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      data: {
+        charts: [
+          {
+            id: 'c1',
+            name: 'Test',
+            workingTree: { id: 'r', name: 'R', title: 'T' },
+            categories: [],
+          },
+        ],
+        versions: [],
+        settings: null,
+        theme: null,
+        csvMappings: null,
+        customPresets: null,
+        accordionState: null,
+      },
+    };
+
+    it('shows a warning confirmation when auto-backup fails before replace', async () => {
+      const { element } = buildPanel();
+      const restoreBtn = getRestoreButton(element);
+      const { getInput, cleanup } = setupFileInputCapture();
+
+      (readBackupFile as Mock).mockResolvedValue(validBackup);
+      (getBackupSummary as Mock).mockReturnValue({
+        chartCount: 1,
+        versionCount: 0,
+        appVersion: '1.0.0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      });
+      (showRestoreStrategyDialog as Mock).mockResolvedValue('replace');
+      (createBackup as Mock).mockRejectedValueOnce(new Error('Backup creation failed'));
+      (showConfirmDialog as Mock).mockResolvedValueOnce(false);
+
+      restoreBtn.click();
+      const input = getInput();
+      expect(input).not.toBeNull();
+      triggerFileChange(input!, validBackup);
+
+      await vi.waitFor(() => {
+        expect(showConfirmDialog).toHaveBeenCalled();
+      });
+
+      const firstCall = (showConfirmDialog as Mock).mock.calls[0][0];
+      expect(firstCall.danger).toBe(true);
+      expect(firstCall.message).toMatch(/backup|failed|no backup/i);
+      cleanup();
+    });
+
+    it('does not proceed to replace when user declines after backup failure warning', async () => {
+      const { element } = buildPanel();
+      const restoreBtn = getRestoreButton(element);
+      const { getInput, cleanup } = setupFileInputCapture();
+
+      (readBackupFile as Mock).mockResolvedValue(validBackup);
+      (getBackupSummary as Mock).mockReturnValue({
+        chartCount: 1,
+        versionCount: 0,
+        appVersion: '1.0.0',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      });
+      (showRestoreStrategyDialog as Mock).mockResolvedValue('replace');
+      (createBackup as Mock).mockRejectedValueOnce(new Error('fail'));
+      (showConfirmDialog as Mock).mockResolvedValueOnce(false);
+
+      restoreBtn.click();
+      const input = getInput();
+      expect(input).not.toBeNull();
+      triggerFileChange(input!, validBackup);
+
+      await vi.waitFor(() => {
+        expect(showConfirmDialog).toHaveBeenCalled();
+      });
+
+      // Only the warning dialog should have been shown, not the replace confirmation
+      expect(showConfirmDialog).toHaveBeenCalledTimes(1);
+      // restoreFullReplace should NOT have been called
+      expect(restoreFullReplace).not.toHaveBeenCalled();
+      cleanup();
     });
   });
 });

--- a/tests/store/backup-manager.test.ts
+++ b/tests/store/backup-manager.test.ts
@@ -393,6 +393,12 @@ describe('BackupManager', () => {
       const existing = [makeChart('e1', 'Existing')];
       const existingVersions = [makeVersion('ve1', 'e1')];
       const db = createMockDB(existing, existingVersions);
+      const storage = {
+        getItem: vi.fn((key: string) => (key === 'arbol-settings' ? '{"old":true}' : null)),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      };
 
       // Make putChart throw to simulate a write failure
       const putChartFn = db.putChart as ReturnType<typeof vi.fn>;
@@ -400,9 +406,156 @@ describe('BackupManager', () => {
 
       const backup = makeValidBackup();
 
-      await expect(restoreFullReplace(db, backup)).rejects.toThrow();
+      await expect(restoreFullReplace(db, backup, storage)).rejects.toThrow();
 
-      // Existing data should be preserved (rollback)
+      // Existing chart should be preserved (rollback)
+      const charts = await db.getAllCharts();
+      expect(charts).toHaveLength(1);
+      expect(charts[0].id).toBe('e1');
+
+      // Existing versions should be preserved
+      const versions = await db.getVersionsByChart('e1');
+      expect(versions).toHaveLength(1);
+      expect(versions[0].id).toBe('ve1');
+
+      // localStorage should be restored
+      expect(storage.setItem).toHaveBeenCalledWith('arbol-settings', '{"old":true}');
+    });
+
+    it('cleans up partial writes when a later write fails mid-restore', async () => {
+      const existing = [makeChart('e1', 'Existing')];
+      const db = createMockDB(existing);
+      const storage = {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      };
+
+      const chart1 = makeChart('b1', 'Backup1');
+      const chart2 = makeChart('b2', 'Backup2');
+      const backup = makeValidBackup({
+        data: {
+          charts: [chart1, chart2],
+          versions: [],
+          settings: null,
+          theme: null,
+          csvMappings: null,
+          customPresets: null,
+          accordionState: null,
+        },
+      });
+
+      // First putChart succeeds (writing chart1), second fails (writing chart2)
+      const putChartFn = db.putChart as ReturnType<typeof vi.fn>;
+      putChartFn
+        .mockResolvedValueOnce(undefined) // succeeds for chart1
+        .mockRejectedValueOnce(new Error('Write failed')); // fails for chart2
+
+      await expect(restoreFullReplace(db, backup, storage)).rejects.toThrow();
+
+      // Rollback should have restored original data — no mixed old+new state
+      const charts = await db.getAllCharts();
+      expect(charts).toHaveLength(1);
+      expect(charts[0].id).toBe('e1');
+    });
+
+    it('removes originally-absent localStorage keys during rollback', async () => {
+      const existing = [makeChart('e1', 'Existing')];
+      const db = createMockDB(existing);
+      const lsStore: Record<string, string> = { 'arbol-settings': '{"v":1}' };
+      const storage = {
+        getItem: vi.fn((key: string) => lsStore[key] ?? null),
+        setItem: vi.fn((key: string, val: string) => {
+          lsStore[key] = val;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete lsStore[key];
+        }),
+        clear: vi.fn(),
+      };
+
+      const backup = makeValidBackup({
+        data: {
+          charts: [makeChart('c1', 'Chart')],
+          versions: [],
+          settings: { newSettings: true },
+          theme: 'dark',
+          csvMappings: null,
+          customPresets: null,
+          accordionState: null,
+        },
+      });
+
+      // Make putChart fail to trigger rollback
+      const putChartFn = db.putChart as ReturnType<typeof vi.fn>;
+      putChartFn.mockRejectedValueOnce(new Error('fail'));
+
+      await expect(restoreFullReplace(db, backup, storage)).rejects.toThrow();
+
+      // arbol-settings was present → should be restored
+      expect(storage.setItem).toHaveBeenCalledWith('arbol-settings', '{"v":1}');
+      // arbol-theme was absent → should be explicitly removed (not left with backup value)
+      expect(storage.removeItem).toHaveBeenCalledWith('arbol-theme');
+    });
+
+    it('rollback continues past individual recovery failures', async () => {
+      const existing = [makeChart('e1', 'Existing'), makeChart('e2', 'Existing2')];
+      const existingVersions = [makeVersion('ve1', 'e1')];
+      const db = createMockDB(existing, existingVersions);
+      const storage = {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      };
+
+      const backup = makeValidBackup();
+
+      // Make the initial putChart fail to trigger rollback
+      const putChartFn = db.putChart as ReturnType<typeof vi.fn>;
+      putChartFn
+        .mockRejectedValueOnce(new Error('write fail')) // triggers rollback
+        .mockRejectedValueOnce(new Error('rollback fail for e1')) // first rollback putChart fails
+        .mockResolvedValueOnce(undefined); // second rollback putChart succeeds
+
+      await expect(restoreFullReplace(db, backup, storage)).rejects.toThrow('write fail');
+
+      // Despite e1 rollback failing, e2 should still have been attempted
+      expect(putChartFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('rolls back on version write failure', async () => {
+      const existing = [makeChart('e1', 'Existing')];
+      const db = createMockDB(existing);
+      const storage = {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      };
+
+      const backup = makeValidBackup({
+        data: {
+          charts: [makeChart('c1', 'Chart')],
+          versions: [makeVersion('v1', 'c1'), makeVersion('v2', 'c1')],
+          settings: null,
+          theme: null,
+          csvMappings: null,
+          customPresets: null,
+          accordionState: null,
+        },
+      });
+
+      // putChart succeeds, first putVersion succeeds, second fails
+      const putVersionFn = db.putVersion as ReturnType<typeof vi.fn>;
+      putVersionFn
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('version write failed'));
+
+      await expect(restoreFullReplace(db, backup, storage)).rejects.toThrow();
+
+      // Rollback should have restored original data
       const charts = await db.getAllCharts();
       expect(charts).toHaveLength(1);
       expect(charts[0].id).toBe('e1');
@@ -553,11 +706,7 @@ describe('BackupManager', () => {
 
       const backup = makeValidBackup({
         data: {
-          charts: [
-            makeChart('c1', 'Dup1'),
-            makeChart('c2', 'New1'),
-            makeChart('c3', 'New2'),
-          ],
+          charts: [makeChart('c1', 'Dup1'), makeChart('c2', 'New1'), makeChart('c3', 'New2')],
           versions: [
             makeVersion('v1', 'c1'),
             makeVersion('v2', 'c2'),

--- a/tests/store/backup-manager.test.ts
+++ b/tests/store/backup-manager.test.ts
@@ -363,6 +363,51 @@ describe('BackupManager', () => {
       expect(db.putChart).not.toHaveBeenCalled();
     });
 
+    it('skips versions with invalid tree during full replace', async () => {
+      const validVersion = makeVersion('v-good', 'c1');
+      const invalidVersion: VersionRecord = {
+        ...makeVersion('v-bad', 'c1'),
+        tree: { id: '', name: 'Bad', title: 'No ID' } as never,
+      };
+
+      const backup = makeValidBackup({
+        data: {
+          charts: [makeChart('c1', 'Chart')],
+          versions: [validVersion, invalidVersion],
+          settings: null,
+          theme: null,
+          csvMappings: null,
+          customPresets: null,
+          accordionState: null,
+        },
+      });
+
+      const db = createMockDB();
+      await restoreFullReplace(db, backup);
+
+      expect(db.putVersion).toHaveBeenCalledTimes(1);
+      expect(db.putVersion).toHaveBeenCalledWith(validVersion);
+    });
+
+    it('preserves existing data when backup write fails mid-restore', async () => {
+      const existing = [makeChart('e1', 'Existing')];
+      const existingVersions = [makeVersion('ve1', 'e1')];
+      const db = createMockDB(existing, existingVersions);
+
+      // Make putChart throw to simulate a write failure
+      const putChartFn = db.putChart as ReturnType<typeof vi.fn>;
+      putChartFn.mockRejectedValueOnce(new Error('IndexedDB write failed'));
+
+      const backup = makeValidBackup();
+
+      await expect(restoreFullReplace(db, backup)).rejects.toThrow();
+
+      // Existing data should be preserved (rollback)
+      const charts = await db.getAllCharts();
+      expect(charts).toHaveLength(1);
+      expect(charts[0].id).toBe('e1');
+    });
+
     it('skips charts with name exceeding 500 chars', async () => {
       const longNameChart: ChartRecord = {
         ...makeChart('long', 'Long Name'),
@@ -474,6 +519,33 @@ describe('BackupManager', () => {
       // Versions for invalid chart should not be restored
       expect(db.putVersion).toHaveBeenCalledTimes(1);
       expect(db.putVersion).toHaveBeenCalledWith(expect.objectContaining({ chartId: 'good' }));
+    });
+
+    it('skips versions with invalid tree during merge', async () => {
+      const validVersion = makeVersion('v-good', 'c2');
+      const invalidVersion: VersionRecord = {
+        ...makeVersion('v-bad', 'c2'),
+        tree: { id: '', name: 'Bad', title: 'No ID' } as never,
+      };
+
+      const backup = makeValidBackup({
+        data: {
+          charts: [makeChart('c2', 'New Chart')],
+          versions: [validVersion, invalidVersion],
+          settings: null,
+          theme: null,
+          csvMappings: null,
+          customPresets: null,
+          accordionState: null,
+        },
+      });
+
+      const db = createMockDB();
+      const result = await restoreMerge(db, backup);
+
+      expect(db.putVersion).toHaveBeenCalledTimes(1);
+      expect(db.putVersion).toHaveBeenCalledWith(validVersion);
+      expect(result.versionsAdded).toBe(1);
     });
 
     it('returns accurate MergeResult summary', async () => {


### PR DESCRIPTION
## Summary

Fixes three critical backup safety issues:

- **#14**: Backup restore is now atomic — validates all data before deleting, rolls back on failure
- **#15**: Clear-all/Replace blocks when backup fails — shows explicit warning dialog
- **#16**: Version trees are validated before persistence in both full-replace and merge paths

## Changes

### \src/store/backup-manager.ts\
- \estoreFullReplace()\: 4-stage atomic process (validate → snapshot → delete → write with rollback)
- \estoreMerge()\: validates version trees before \putVersion()\

### \src/editor/settings/backup-panel.ts\
- Clear-all and Replace paths now show backup-failure warning dialog

### i18n
- New keys: \ackup.clear_no_backup_title/message/confirm\ (en, es)

## Test plan
- 5 new tests (3 backup-manager, 2 backup-panel)
- Full suite: 2803 tests passing