### PR TITLE
refactor(layout): replace O(n²) shiftSubtree with single-pass offset accumulation (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clear-all blocks on backup failure** — destructive "Clear All Data" and "Replace" actions now show an explicit warning dialog when the auto-backup fails, requiring user acknowledgment before proceeding (#15)
 - **Version tree validation** — `restoreFullReplace()` and `restoreMerge()` now validate version trees before persisting; malformed versions are skipped with a warning (#16)
 - **Bundle import metadata validation** — `importChartAsNew()` and `importChartReplaceCurrent()` now validate categories, levelMappings, and levelDisplayMode; malformed categories are stripped, malformed levelMappings entries are sanitized (valid kept), and invalid levelDisplayMode values are rejected (#17)
+- **Layout engine performance** — replaced O(n²) recursive `shiftSubtree` calls with single-pass O(n) offset accumulation for vertical spacing adjustments (#18)
 
 ## [3.12.1] — 2026-03-22
 

--- a/src/renderer/layout-engine.ts
+++ b/src/renderer/layout-engine.ts
@@ -110,32 +110,33 @@ export function computeLayout(root: OrgNode, opts: ResolvedOptions): LayoutResul
     return palTopGap + palRowGap + rows * nodeHeight + (rows - 1) * palRowGap + palBottomGap;
   };
 
-  // Shift a subtree vertically
-  const shiftSubtree = (node: HierarchyPointNode<OrgNode>, extraY: number): void => {
-    node.y += extraY;
-    for (const child of node.children ?? []) {
-      shiftSubtree(child, extraY);
+  // Apply vertical shifts for Advisor stacks, single-child, and multi-child nodes.
+  // Uses a single O(n) top-down pass with accumulated offsets instead of
+  // recursive shiftSubtree calls per node (which was O(n²) on deep/skewed trees).
+  const extraNonPalShift = bottomVerticalSpacing - topVerticalSpacing;
+
+  const applyShifts = (node: HierarchyPointNode<OrgNode>, accumulated: number): void => {
+    node.y += accumulated;
+
+    if (!node.children) return;
+
+    let childExtra = 0;
+    const palHeight = getPalStackHeight(node.data.id);
+    if (palHeight > 0) {
+      childExtra = palHeight;
+    } else if (node.children.length === 1) {
+      childExtra = -topVerticalSpacing;
+    } else if (extraNonPalShift > 0 && node.children.length > 1) {
+      childExtra = extraNonPalShift;
+    }
+
+    for (const child of node.children) {
+      applyShifts(child, accumulated + childExtra);
     }
   };
 
-  // Apply vertical shifts for Advisor stacks, single-child, and multi-child nodes
-  const extraNonPalShift = bottomVerticalSpacing - topVerticalSpacing;
-  for (const node of treeData.descendants()) {
-    const palHeight = getPalStackHeight(node.data.id);
-    if (palHeight > 0 && node.children) {
-      for (const child of node.children) {
-        shiftSubtree(child, palHeight);
-      }
-    } else if (node.children && node.children.length === 1) {
-      for (const child of node.children) {
-        shiftSubtree(child, -topVerticalSpacing);
-      }
-    } else if (extraNonPalShift > 0 && node.children && node.children.length > 1) {
-      for (const child of node.children) {
-        shiftSubtree(child, extraNonPalShift);
-      }
-    }
-  }
+  // Root has no parent shift
+  applyShifts(treeData, 0);
 
   // Enforce branchSpacing: ensure subtree bounding boxes don't overlap.
   // boundsCache is a local variable — recreated each computeLayout() call


### PR DESCRIPTION
## Summary

Fixes #18: Layout hot path no longer repeatedly shifts whole subtrees.

### Problem
\shiftSubtree()\ recursively walked all descendants for each node in the \descendants()\ loop, creating O(n²) work on deep/skewed trees.

### Fix
Single top-down traversal with accumulated vertical offsets — O(n) instead of O(n²). Same layout output (41 existing layout tests pass unchanged).

### Changed files
- \src/renderer/layout-engine.ts\ — replaced shiftSubtree + loop with applyShifts single-pass
- \CHANGELOG.md\ — updated

This is a behavior-preserving \efactor\ commit (TDD-exempt).