### PR TITLE
feat(help): show help dialog with Getting Started on first visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **First-visit onboarding** — when Arbol is opened for the first time, the Help & Reference dialog opens automatically with the "Getting Started" section expanded, replacing the simple welcome banner
+- **`initialSection` option for help dialog** — `showHelpDialog()` now accepts an `initialSection` parameter to control which accordion section is expanded by default
+
 ### Fixed
 
 - **Backup restore with best-effort rollback** — `restoreFullReplace()` validates all data before deleting existing charts; if writing fails, original data is restored on a best-effort basis (#14)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ An interactive org chart editor for the browser — manage multiple org charts w
 - **Accessible org chart** — full keyboard navigation (arrow keys, Enter, Space), ARIA tree semantics, screen reader announcements
 - **Mobile responsive** — collapsible sidebar on tablet/phone, touch-friendly 44px targets, works at 200% zoom
 - **i18n ready** — translation infrastructure with 400+ extractable strings, RTL-ready CSS logical properties
-- **First-time guidance** — welcome banner for new users, contextual "no results" hints
+- **First-time guidance** — help dialog with Getting Started guide for new users, contextual "no results" hints
 - **Loading indicators** — visual feedback for exports, imports, chart switching
 - Interactive hierarchical org chart visualization
 - Four sidebar tabs: People (add/edit), Import (files, paste, JSON editor, text normalization), Settings (presets, categories, fine-tuning), Charts (chart & version management)

--- a/src/init/first-visit-helper.ts
+++ b/src/init/first-visit-helper.ts
@@ -1,0 +1,18 @@
+import { showHelpDialog } from '../ui/help-dialog';
+import { type IStorage, browserStorage } from '../utils/storage';
+
+const WELCOME_KEY = 'arbol-welcome-seen';
+
+export function showFirstVisitHelp(
+  onLoadSample: () => void,
+  storage: IStorage = browserStorage,
+): boolean {
+  if (storage.getItem(WELCOME_KEY)) return false;
+
+  showHelpDialog({
+    initialSection: 1,
+    onLoadSample,
+  });
+  storage.setItem(WELCOME_KEY, 'true');
+  return true;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,15 +34,26 @@ import { FocusModeController } from './controllers/focus-mode';
 import { SelectionManager } from './controllers/selection-manager';
 import { SearchController } from './controllers/search-controller';
 import { announce } from './ui/announcer';
-import { createShowSingleCardMenu, createShowMultiSelectMenu, type ContextMenuDeps } from './init/context-menu-handler';
+import {
+  createShowSingleCardMenu,
+  createShowMultiSelectMenu,
+  type ContextMenuDeps,
+} from './init/context-menu-handler';
 import { buildToolbar, type ToolbarElements } from './init/toolbar-builder';
 import { buildFooter } from './init/footer-builder';
-import { showWelcomeBanner } from './ui/welcome-banner';
+import { showHelpDialog } from './ui/help-dialog';
+import { SAMPLE_ORG } from './data/sample-org';
 import { PropertyPanel } from './ui/property-panel';
 import { SettingsModal } from './ui/settings-modal';
 import { SettingsEditor } from './editor/settings-editor';
 import { ImportWizard } from './ui/import-wizard';
-import { WizardState, renderSourceStep, renderMappingStep, renderPreviewStep, renderImportStep } from './ui/import-wizard-steps';
+import {
+  WizardState,
+  renderSourceStep,
+  renderMappingStep,
+  renderPreviewStep,
+  renderImportStep,
+} from './ui/import-wizard-steps';
 import { registerShortcuts } from './init/shortcuts-handler';
 import type { ChartRecord, VersionRecord } from './types';
 import { AnalyticsDrawer } from './ui/analytics-drawer';
@@ -54,7 +65,8 @@ async function main(): Promise<void> {
 
   // Offscreen host for editors that need to exist but aren't visible in the sidebar
   const offscreenHost = document.createElement('div');
-  offscreenHost.style.cssText = 'position:absolute;left:-9999px;top:-9999px;width:0;height:0;overflow:hidden;';
+  offscreenHost.style.cssText =
+    'position:absolute;left:-9999px;top:-9999px;width:0;height:0;overflow:hidden;';
   document.body.appendChild(offscreenHost);
 
   // Load saved locale preference, default to 'en'
@@ -111,14 +123,19 @@ async function main(): Promise<void> {
   // Load per-chart level mappings
   levelStore.loadFromChart(activeChart);
 
-  const resolveTitle = (originalTitle: string, rawLevel?: string, isManager?: boolean, pinnedTitle?: boolean): string => {
+  const resolveTitle = (
+    originalTitle: string,
+    rawLevel?: string,
+    isManager?: boolean,
+    pinnedTitle?: boolean,
+  ): string => {
     if (pinnedTitle) return originalTitle;
     if (!rawLevel) return originalTitle;
     const mapped = levelStore.resolveTitle(rawLevel, isManager);
     return mapped ?? originalTitle;
   };
 
-  const renderer= new ChartRenderer({
+  const renderer = new ChartRenderer({
     container: chartArea,
     ...savedSettings,
     textAlign: savedSettings.textAlign as 'left' | 'center' | 'right',
@@ -140,11 +157,20 @@ async function main(): Promise<void> {
 
   const debouncedSave = debounce(() => {
     const fullTree = store.getTree();
-    chartStore.saveWorkingTree(fullTree, categoryStore.getAll(), store.mutationVersion, levelStore.toChartData()).catch((err) => {
-      console.error('Failed to save working tree:', err);
-      const isQuota = err instanceof DOMException && (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED');
-      showToast(t(isQuota ? 'error.storage_save_failed' : 'footer.save_failed'), 'error');
-    });
+    chartStore
+      .saveWorkingTree(
+        fullTree,
+        categoryStore.getAll(),
+        store.mutationVersion,
+        levelStore.toChartData(),
+      )
+      .catch((err) => {
+        console.error('Failed to save working tree:', err);
+        const isQuota =
+          err instanceof DOMException &&
+          (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+        showToast(t(isQuota ? 'error.storage_save_failed' : 'footer.save_failed'), 'error');
+      });
   }, 500);
 
   const rerender = () => {
@@ -170,14 +196,20 @@ async function main(): Promise<void> {
     // Update category legend on the chart
     const categories = categoryStore.getAll();
     if (categories.length > 0) {
-      showCategoryLegend({ categories, container: chartArea, legendRows: renderer.getOptions().legendRows });
+      showCategoryLegend({
+        categories,
+        container: chartArea,
+        legendRows: renderer.getOptions().legendRows,
+      });
     } else {
       dismissCategoryLegend();
     }
 
     // Hide legend when analytics drawer is open
     if (analyticsDrawer?.isOpen()) {
-      const legend = chartArea.querySelector('[data-testid="category-legend"]') as HTMLElement | null;
+      const legend = chartArea.querySelector(
+        '[data-testid="category-legend"]',
+      ) as HTMLElement | null;
       if (legend) legend.style.display = 'none';
     }
   };
@@ -215,13 +247,13 @@ async function main(): Promise<void> {
 
   // Settings modal (opens via header button)
   const SECTION_TAB_MAP: Record<string, string> = {
-    'presets': 'presets',
-    'categories': 'categories',
+    presets: 'presets',
+    categories: 'categories',
     'card-dimensions': 'layout',
     'tree-spacing': 'layout',
     'ic-options': 'ic',
     'advisor-options': 'advisors',
-    'typography': 'typography',
+    typography: 'typography',
     'link-style': 'connectors',
     'card-style': 'cards',
     'headcount-badge': 'badges',
@@ -230,7 +262,6 @@ async function main(): Promise<void> {
     'level-mapping': 'level_mapping',
     'settings-io': 'backup',
     'backup-restore': 'backup',
-
   };
 
   function filterSettingsSections(tabId: string): void {
@@ -280,7 +311,9 @@ async function main(): Promise<void> {
         settingsSnapshot = null;
       }
     },
-    onTabChange: (tabId) => { filterSettingsSections(tabId); },
+    onTabChange: (tabId) => {
+      filterSettingsSections(tabId);
+    },
   });
 
   // Import wizard (opens via header button)
@@ -293,13 +326,20 @@ async function main(): Promise<void> {
       { id: 'preview', label: t('import_wizard.step_preview') },
       { id: 'import', label: t('import_wizard.step_import') },
     ],
-    onClose: () => { wizardState = {}; },
+    onClose: () => {
+      wizardState = {};
+    },
     onStepChange: async (stepId) => {
       const content = importWizard.getStepContentArea();
       const setNext = (ready: boolean) => importWizard.setNextEnabled(ready);
 
       // Prompt to save preset when leaving mapping step with a new mapping
-      if (stepId === 'preview' && wizardState.format === 'CSV' && wizardState.mapping && !wizardState.matchedPresetName) {
+      if (
+        stepId === 'preview' &&
+        wizardState.format === 'CSV' &&
+        wizardState.mapping &&
+        !wizardState.matchedPresetName
+      ) {
         // Suggest name from filename (e.g. "hr-export.csv" → "hr-export")
         const suggestedName = wizardState.fileName
           ? wizardState.fileName.replace(/\.[^.]+$/, '')
@@ -318,10 +358,18 @@ async function main(): Promise<void> {
       }
 
       switch (stepId) {
-        case 'source': renderSourceStep(content, wizardState, setNext); break;
-        case 'mapping': renderMappingStep(content, wizardState, setNext, mappingStore.getPresets()); break;
-        case 'preview': renderPreviewStep(content, wizardState, setNext); break;
-        case 'import': renderImportStep(content, wizardState, setNext); break;
+        case 'source':
+          renderSourceStep(content, wizardState, setNext);
+          break;
+        case 'mapping':
+          renderMappingStep(content, wizardState, setNext, mappingStore.getPresets());
+          break;
+        case 'preview':
+          renderPreviewStep(content, wizardState, setNext);
+          break;
+        case 'import':
+          renderImportStep(content, wizardState, setNext);
+          break;
       }
     },
     onComplete: async () => {
@@ -330,7 +378,11 @@ async function main(): Promise<void> {
         let finalTree = wizardState.tree;
         if (wizardState.nameNormalization || wizardState.titleNormalization) {
           const { normalizeTreeText } = await import('./utils/text-normalize');
-          finalTree = normalizeTreeText(finalTree, wizardState.nameNormalization ?? 'none', wizardState.titleNormalization ?? 'none');
+          finalTree = normalizeTreeText(
+            finalTree,
+            wizardState.nameNormalization ?? 'none',
+            wizardState.titleNormalization ?? 'none',
+          );
         }
         if (wizardState.destination === 'new' && wizardState.chartName) {
           const chart = await chartStore.createChartFromTree(wizardState.chartName, finalTree);
@@ -403,7 +455,9 @@ async function main(): Promise<void> {
       const content = importWizard.getStepContentArea();
       renderSourceStep(content, wizardState, (ready) => importWizard.setNextEnabled(ready));
     },
-    onExportClick: () => { exportCurrentChart(); },
+    onExportClick: () => {
+      exportCurrentChart();
+    },
   });
   const { undoBtn, redoBtn, settingsBtn, importBtn } = toolbar;
 
@@ -666,7 +720,9 @@ async function main(): Promise<void> {
     tooltip: t('analytics.drawer_toggle_tooltip'),
     ariaLabel: t('analytics.drawer_toggle_tooltip'),
     ariaKeyshortcuts: 'Control+Shift+a',
-    onClick: () => { analyticsDrawer.toggle(); },
+    onClick: () => {
+      analyticsDrawer.toggle();
+    },
   });
   headerRight.insertBefore(analyticsToggleBtn, toolbar.themeBtn);
 
@@ -728,7 +784,9 @@ async function main(): Promise<void> {
       showAddPopover({
         anchor: rect,
         parentName: node.name,
-        onAdd: (name, title) => { store.addChild(nodeId, { name, title }); },
+        onAdd: (name, title) => {
+          store.addChild(nodeId, { name, title });
+        },
         onCancel: () => {},
       });
     },
@@ -746,15 +804,22 @@ async function main(): Promise<void> {
         title: t('picker.move_to', { name: node.name }),
         managers,
         showDottedLineOption: true,
-      }).then((result) => {
-        if (result) {
-          store.moveNode(nodeId, result.managerId, result.dottedLine);
-          const targetNode = findNodeById(tree, result.managerId);
-          announce(t('announce.moved', { name: node.name, target: targetNode?.name ?? t('announce.move_fallback_target') }));
-        }
-      }).catch((e) => {
-        showToast(e instanceof Error ? e.message : String(e), 'error');
-      });
+      })
+        .then((result) => {
+          if (result) {
+            store.moveNode(nodeId, result.managerId, result.dottedLine);
+            const targetNode = findNodeById(tree, result.managerId);
+            announce(
+              t('announce.moved', {
+                name: node.name,
+                target: targetNode?.name ?? t('announce.move_fallback_target'),
+              }),
+            );
+          }
+        })
+        .catch((e) => {
+          showToast(e instanceof Error ? e.message : String(e), 'error');
+        });
     },
     onRemove: (nodeId) => {
       const tree = store.getTree();
@@ -778,7 +843,10 @@ async function main(): Promise<void> {
         const descendantCount = descendants.length - 1;
         showConfirmDialog({
           title: t('dialog.remove_manager.title'),
-          message: t('dialog.remove_manager.message', { name: node.name, count: String(descendantCount) }),
+          message: t('dialog.remove_manager.message', {
+            name: node.name,
+            count: String(descendantCount),
+          }),
           confirmLabel: t('dialog.remove_manager.reassign'),
           cancelLabel: t('dialog.remove_manager.remove_all', { count: String(descendantCount) }),
           danger: false,
@@ -841,7 +909,9 @@ async function main(): Promise<void> {
     const directReports = node.children?.length ?? 0;
     const totalOrg = store.getDescendantCount(nodeId);
     const avgSpan = avgSpanOfControl(node);
-    const categories = categoryStore.getAll().map((c) => ({ id: c.id, label: c.label, color: c.color }));
+    const categories = categoryStore
+      .getAll()
+      .map((c) => ({ id: c.id, label: c.label, color: c.color }));
     propertyPanel.show(node, parent?.name ?? null, directReports, totalOrg, avgSpan, categories);
   };
 
@@ -857,8 +927,17 @@ async function main(): Promise<void> {
       const node = findNodeById(tree, panelNodeId);
       if (node) {
         const parent = findParent(tree, panelNodeId);
-        const categories = categoryStore.getAll().map((c) => ({ id: c.id, label: c.label, color: c.color }));
-        propertyPanel.update(node, parent?.name ?? null, node.children?.length ?? 0, store.getDescendantCount(panelNodeId), avgSpanOfControl(node), categories);
+        const categories = categoryStore
+          .getAll()
+          .map((c) => ({ id: c.id, label: c.label, color: c.color }));
+        propertyPanel.update(
+          node,
+          parent?.name ?? null,
+          node.children?.length ?? 0,
+          store.getDescendantCount(panelNodeId),
+          avgSpanOfControl(node),
+          categories,
+        );
       } else {
         propertyPanel.hide();
         renderer.setSelectedNode(null);
@@ -1021,7 +1100,15 @@ async function main(): Promise<void> {
   });
 
   rerender();
-  showWelcomeBanner(chartArea);
+
+  const WELCOME_KEY = 'arbol-welcome-seen';
+  if (!localStorage.getItem(WELCOME_KEY)) {
+    showHelpDialog({
+      initialSection: 1,
+      onLoadSample: () => store.fromJSON(JSON.stringify(SAMPLE_ORG)),
+    });
+    localStorage.setItem(WELCOME_KEY, 'true');
+  }
 }
 
 window.addEventListener('unhandledrejection', (event) => {
@@ -1045,7 +1132,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const message = document.createElement('p');
       message.textContent = e instanceof Error ? e.message : 'An unexpected error occurred';
       const hint = document.createElement('p');
-      hint.textContent = t('app.refresh_hint') || 'Try refreshing the page. If the issue persists, clear your browser data for this site.';
+      hint.textContent =
+        t('app.refresh_hint') ||
+        'Try refreshing the page. If the issue persists, clear your browser data for this site.';
       errorDiv.appendChild(heading);
       errorDiv.appendChild(message);
       errorDiv.appendChild(hint);

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,9 +39,9 @@ import {
   createShowMultiSelectMenu,
   type ContextMenuDeps,
 } from './init/context-menu-handler';
-import { buildToolbar, type ToolbarElements } from './init/toolbar-builder';
+import { buildToolbar } from './init/toolbar-builder';
 import { buildFooter } from './init/footer-builder';
-import { showHelpDialog } from './ui/help-dialog';
+import { showFirstVisitHelp } from './init/first-visit-helper';
 import { SAMPLE_ORG } from './data/sample-org';
 import { PropertyPanel } from './ui/property-panel';
 import { SettingsModal } from './ui/settings-modal';
@@ -55,7 +55,7 @@ import {
   renderImportStep,
 } from './ui/import-wizard-steps';
 import { registerShortcuts } from './init/shortcuts-handler';
-import type { ChartRecord, VersionRecord } from './types';
+import type { ChartRecord } from './types';
 import { AnalyticsDrawer } from './ui/analytics-drawer';
 import { AnalyticsEditor } from './editor/analytics-editor';
 
@@ -1101,14 +1101,7 @@ async function main(): Promise<void> {
 
   rerender();
 
-  const WELCOME_KEY = 'arbol-welcome-seen';
-  if (!localStorage.getItem(WELCOME_KEY)) {
-    showHelpDialog({
-      initialSection: 1,
-      onLoadSample: () => store.fromJSON(JSON.stringify(SAMPLE_ORG)),
-    });
-    localStorage.setItem(WELCOME_KEY, 'true');
-  }
+  showFirstVisitHelp(() => store.fromJSON(JSON.stringify(SAMPLE_ORG)));
 }
 
 window.addEventListener('unhandledrejection', (event) => {

--- a/src/ui/help-dialog.ts
+++ b/src/ui/help-dialog.ts
@@ -66,10 +66,7 @@ function getHelpSections(): HelpSection[] {
           { tag: 'strong', text: t('help.chart_works.managers_label') },
           t('help.chart_works.managers_desc'),
         ],
-        [
-          { tag: 'strong', text: t('help.chart_works.ics_label') },
-          t('help.chart_works.ics_desc'),
-        ],
+        [{ tag: 'strong', text: t('help.chart_works.ics_label') }, t('help.chart_works.ics_desc')],
         [
           { tag: 'strong', text: t('help.chart_works.advisors_label') },
           t('help.chart_works.advisors_desc'),
@@ -129,14 +126,8 @@ function getHelpSections(): HelpSection[] {
           t('help.importing.how_2'),
         ],
         [t('help.importing.wizard')],
-        [
-          { tag: 'strong', text: t('help.importing.json_label') },
-          t('help.importing.json_desc'),
-        ],
-        [
-          { tag: 'strong', text: t('help.importing.csv_label') },
-          t('help.importing.csv_desc'),
-        ],
+        [{ tag: 'strong', text: t('help.importing.json_label') }, t('help.importing.json_desc')],
+        [{ tag: 'strong', text: t('help.importing.csv_label') }, t('help.importing.csv_desc')],
         [t('help.importing.normalize')],
         [t('help.importing.limit')],
       ],
@@ -237,18 +228,9 @@ function getHelpSections(): HelpSection[] {
           { tag: 'strong', text: t('help.analytics.headcount_label') },
           t('help.analytics.headcount_desc'),
         ],
-        [
-          { tag: 'strong', text: t('help.analytics.depth_label') },
-          t('help.analytics.depth_desc'),
-        ],
-        [
-          { tag: 'strong', text: t('help.analytics.ratio_label') },
-          t('help.analytics.ratio_desc'),
-        ],
-        [
-          { tag: 'strong', text: t('help.analytics.span_label') },
-          t('help.analytics.span_desc'),
-        ],
+        [{ tag: 'strong', text: t('help.analytics.depth_label') }, t('help.analytics.depth_desc')],
+        [{ tag: 'strong', text: t('help.analytics.ratio_label') }, t('help.analytics.ratio_desc')],
+        [{ tag: 'strong', text: t('help.analytics.span_label') }, t('help.analytics.span_desc')],
         [
           { tag: 'strong', text: t('help.analytics.alerts_label') },
           t('help.analytics.alerts_desc'),
@@ -258,9 +240,7 @@ function getHelpSections(): HelpSection[] {
     },
     {
       titleKey: 'help.comparison.title',
-      items: [
-        [t('help.comparison.desc')],
-      ],
+      items: [[t('help.comparison.desc')]],
     },
     {
       titleKey: 'help.your_data.title',
@@ -296,20 +276,14 @@ function getHelpSections(): HelpSection[] {
     {
       titleKey: 'help.exporting.title',
       items: [
-        [
-          { tag: 'strong', text: t('help.exporting.pptx_label') },
-          t('help.exporting.pptx_desc'),
-        ],
+        [{ tag: 'strong', text: t('help.exporting.pptx_label') }, t('help.exporting.pptx_desc')],
         [t('help.exporting.versions')],
         [t('help.exporting.scale')],
       ],
     },
     {
       titleKey: 'help.links.title',
-      items: [
-        [t('help.links.built_with')],
-        [t('help.links.report_bugs')],
-      ],
+      items: [[t('help.links.built_with')], [t('help.links.report_bugs')]],
     },
   ];
 }
@@ -431,6 +405,7 @@ function buildSampleOrgButton(onLoad: () => void, closeDialog: () => void): HTML
 export interface HelpDialogOptions {
   storage?: IStorage;
   onLoadSample?: () => void;
+  initialSection?: number;
 }
 
 export function showHelpDialog(options: HelpDialogOptions = {}): void {
@@ -488,18 +463,19 @@ export function showHelpDialog(options: HelpDialogOptions = {}): void {
   content.style.scrollbarWidth = 'thin';
 
   const sections = getHelpSections();
+  const initialSection = options.initialSection ?? 0;
   const closeRef = { fn: () => {} };
   for (let i = 0; i < sections.length; i++) {
     const section = sections[i];
-    const isFirst = i === 0;
+    const isInitial = i === initialSection;
 
     const sectionEl = document.createElement('div');
-    sectionEl.className = isFirst ? 'help-section open' : 'help-section';
+    sectionEl.className = isInitial ? 'help-section open' : 'help-section';
 
     // Accordion header (button for keyboard accessibility)
     const headerBtn = document.createElement('button');
     headerBtn.className = 'help-section-header';
-    headerBtn.setAttribute('aria-expanded', String(isFirst));
+    headerBtn.setAttribute('aria-expanded', String(isInitial));
     const sectionTitle = t(section.titleKey);
     headerBtn.setAttribute('aria-label', t('help.section_toggle_aria', { section: sectionTitle }));
 

--- a/tests/init/first-visit-helper.test.ts
+++ b/tests/init/first-visit-helper.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { showFirstVisitHelp } from '../../src/init/first-visit-helper';
+import type { IStorage } from '../../src/utils/storage';
 
-function makeStorage(): Record<string, string> & {
+function makeStorage(): IStorage & {
   getItem: ReturnType<typeof vi.fn>;
   setItem: ReturnType<typeof vi.fn>;
-  removeItem: ReturnType<typeof vi.fn>;
 } {
   const store: Record<string, string> = {};
   return {
@@ -14,6 +14,9 @@ function makeStorage(): Record<string, string> & {
     }),
     removeItem: vi.fn((key: string) => {
       delete store[key];
+    }),
+    clear: vi.fn(() => {
+      Object.keys(store).forEach((key) => delete store[key]);
     }),
   };
 }

--- a/tests/init/first-visit-helper.test.ts
+++ b/tests/init/first-visit-helper.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { showFirstVisitHelp } from '../../src/init/first-visit-helper';
+
+function makeStorage(): Record<string, string> & {
+  getItem: ReturnType<typeof vi.fn>;
+  setItem: ReturnType<typeof vi.fn>;
+  removeItem: ReturnType<typeof vi.fn>;
+} {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+  };
+}
+
+describe('showFirstVisitHelp', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('shows help dialog on first visit and returns true', () => {
+    const storage = makeStorage();
+    const onLoadSample = vi.fn();
+    const result = showFirstVisitHelp(onLoadSample, storage);
+
+    expect(result).toBe(true);
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it('sets storage flag after showing help', () => {
+    const storage = makeStorage();
+    showFirstVisitHelp(vi.fn(), storage);
+
+    expect(storage.setItem).toHaveBeenCalledWith('arbol-welcome-seen', 'true');
+  });
+
+  it('does not show help dialog on repeat visit', () => {
+    const storage = makeStorage();
+    storage.setItem('arbol-welcome-seen', 'true');
+
+    const result = showFirstVisitHelp(vi.fn(), storage);
+
+    expect(result).toBe(false);
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('opens Getting Started section (index 1) by default', () => {
+    const storage = makeStorage();
+    showFirstVisitHelp(vi.fn(), storage);
+
+    const sections = document.querySelectorAll('.help-section');
+    expect(sections[0].classList.contains('open')).toBe(false);
+    expect(sections[1].classList.contains('open')).toBe(true);
+  });
+
+  it('passes onLoadSample to help dialog', () => {
+    const storage = makeStorage();
+    const onLoadSample = vi.fn();
+    showFirstVisitHelp(onLoadSample, storage);
+
+    const sampleBtn = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Load Sample Org Chart'),
+    );
+    expect(sampleBtn).toBeDefined();
+  });
+});

--- a/tests/ui/help-dialog.test.ts
+++ b/tests/ui/help-dialog.test.ts
@@ -105,8 +105,8 @@ describe('showHelpDialog', () => {
     const headers = document.querySelectorAll('.help-section-header');
     expect(headers.length).toBeGreaterThan(0);
     const headerTexts = Array.from(headers).map((h) => h.textContent);
-    expect(headerTexts.some(t => t!.includes('Getting Started'))).toBe(true);
-    expect(headerTexts.some(t => t!.includes('Keyboard Shortcuts'))).toBe(true);
+    expect(headerTexts.some((t) => t!.includes('Getting Started'))).toBe(true);
+    expect(headerTexts.some((t) => t!.includes('Keyboard Shortcuts'))).toBe(true);
   });
 
   it('contains Your Data section with privacy message', () => {
@@ -118,14 +118,18 @@ describe('showHelpDialog', () => {
 
   it('renders Clear All Data button', () => {
     showHelpDialog();
-    const clearBtn = document.querySelector('[aria-label="Clear all local data"]') as HTMLButtonElement;
+    const clearBtn = document.querySelector(
+      '[aria-label="Clear all local data"]',
+    ) as HTMLButtonElement;
     expect(clearBtn).not.toBeNull();
     expect(clearBtn.textContent).toContain('Clear All Data');
   });
 
   it('Clear All Data button triggers confirmation dialog', async () => {
     showHelpDialog();
-    const clearBtn = document.querySelector('[aria-label="Clear all local data"]') as HTMLButtonElement;
+    const clearBtn = document.querySelector(
+      '[aria-label="Clear all local data"]',
+    ) as HTMLButtonElement;
     clearBtn.click();
 
     // Confirm dialog should appear with danger warning
@@ -242,25 +246,48 @@ describe('showHelpDialog', () => {
 
   it('renders sample org button when onLoadSample is provided', () => {
     showHelpDialog({ onLoadSample: vi.fn() });
-    const btn = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('Load Sample Org Chart'),
+    const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Load Sample Org Chart'),
     );
     expect(btn).toBeDefined();
   });
 
   it('does not render sample org button when onLoadSample is omitted', () => {
     showHelpDialog();
-    const btn = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('Load Sample Org Chart'),
+    const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Load Sample Org Chart'),
     );
     expect(btn).toBeUndefined();
   });
 
   it('sample org button has accessible aria-label', () => {
     showHelpDialog({ onLoadSample: vi.fn() });
-    const btn = Array.from(document.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('Load Sample Org Chart'),
+    const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Load Sample Org Chart'),
     );
     expect(btn!.getAttribute('aria-label')).toBe('Load a sample organization chart');
+  });
+
+  // ─── initialSection Tests ─────────────────────────────────────────
+
+  it('opens Getting Started section when initialSection is 1', () => {
+    showHelpDialog({ initialSection: 1 });
+    const sections = document.querySelectorAll('.help-section');
+    expect(sections[0].classList.contains('open')).toBe(false);
+    expect(sections[1].classList.contains('open')).toBe(true);
+  });
+
+  it('sets aria-expanded correctly for initialSection', () => {
+    showHelpDialog({ initialSection: 1 });
+    const headers = document.querySelectorAll('.help-section-header');
+    expect(headers[0].getAttribute('aria-expanded')).toBe('false');
+    expect(headers[1].getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('defaults to section 0 when initialSection is not provided', () => {
+    showHelpDialog();
+    const sections = document.querySelectorAll('.help-section');
+    expect(sections[0].classList.contains('open')).toBe(true);
+    expect(sections[1].classList.contains('open')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Replace the welcome banner with the full Help & Reference dialog on first visit, with the **Getting Started** section expanded.

### Changes
- Add \initialSection\ option to \showHelpDialog()\ to control which accordion section opens by default
- On first visit (no \rbol-welcome-seen\ in localStorage), auto-open help dialog with Getting Started section (index 1)
- Replace \showWelcomeBanner()\ import with \showHelpDialog()\ in main.ts
- Update CHANGELOG

### TDD Compliance
- \	est(help)\: failing tests for \initialSection\ committed first
- \eat(help)\: implementation committed second — all 2844 tests pass

### Pending
- Sentinel review required before merge