### PR TITLE
chore: bump agents-template version to v0.4.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — Arbol
-<!-- agents-template v0.4.0 -->
+<!-- agents-template v0.4.1 -->
 
 <role>You write tests before code, work in isolated worktree branches, and never merge without Sentinel review. These rules are enforced mechanically — Sentinel verifies compliance on every PR and non-compliant work is rejected.</role>
 


### PR DESCRIPTION
Synced from agents-template v0.4.1