### PR TITLE
fix(help-dialog): reorder sections — Getting Started, Import Instructions, Shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.13.1] — 2026-05-11
+
+### Changed
+
+- **Help dialog section order** — "Getting Started" is now the first section, followed by "Import Instructions" (when configured) and "Keyboard Shortcuts"
 
 ## [3.13.0] — 2026-05-11
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arbol",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arbol",
-      "version": "3.13.0",
+      "version": "3.13.1",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arbol",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "description": "An interactive org chart editor for the browser",
   "directories": {
     "doc": "docs"

--- a/src/init/shortcuts-handler.ts
+++ b/src/init/shortcuts-handler.ts
@@ -1,7 +1,7 @@
 import { t } from '../i18n';
 import { ShortcutManager } from '../utils/shortcuts';
 import { CommandPalette, type CommandItem } from '../ui/command-palette';
-import { showHelpDialog, type HelpDialogOptions } from '../ui/help-dialog';
+import { showHelpDialog } from '../ui/help-dialog';
 import { SAMPLE_ORG } from '../data/sample-org';
 import { showInputDialog } from '../ui/input-dialog';
 import { dismissVersionViewer, isVersionViewerActive } from '../ui/version-viewer';
@@ -70,7 +70,9 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
   shortcuts.register({
     key: 'z',
     ctrl: true,
-    handler: () => { if (store.undo()) announce(t('announce.undo')); },
+    handler: () => {
+      if (store.undo()) announce(t('announce.undo'));
+    },
     description: t('shortcut.undo'),
   });
 
@@ -78,14 +80,18 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
     key: 'z',
     ctrl: true,
     shift: true,
-    handler: () => { if (store.redo()) announce(t('announce.redo')); },
+    handler: () => {
+      if (store.redo()) announce(t('announce.redo'));
+    },
     description: t('shortcut.redo'),
   });
 
   shortcuts.register({
     key: 'y',
     ctrl: true,
-    handler: () => { if (store.redo()) announce(t('announce.redo')); },
+    handler: () => {
+      if (store.redo()) announce(t('announce.redo'));
+    },
     description: t('shortcut.redo_alt'),
   });
 
@@ -118,7 +124,9 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         icon: '📊',
         shortcut: 'Ctrl+E',
         group: t('command_palette.group_actions'),
-        action: () => { exportCurrentChart(); },
+        action: () => {
+          exportCurrentChart();
+        },
       },
       {
         id: 'undo',
@@ -126,7 +134,11 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         icon: '↩',
         shortcut: 'Ctrl+Z',
         group: t('command_palette.group_actions'),
-        action: () => { if (store.undo()) { announce(t('announce.undo')); } },
+        action: () => {
+          if (store.undo()) {
+            announce(t('announce.undo'));
+          }
+        },
       },
       {
         id: 'redo',
@@ -134,7 +146,11 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         icon: '↪',
         shortcut: 'Ctrl+Shift+Z',
         group: t('command_palette.group_actions'),
-        action: () => { if (store.redo()) { announce(t('announce.redo')); } },
+        action: () => {
+          if (store.redo()) {
+            announce(t('announce.redo'));
+          }
+        },
       },
       {
         id: 'settings',
@@ -142,7 +158,9 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         icon: '⚙️',
         shortcut: 'Ctrl+,',
         group: t('command_palette.group_actions'),
-        action: () => { settingsBtn.click(); },
+        action: () => {
+          settingsBtn.click();
+        },
       },
       {
         id: 'search',
@@ -150,7 +168,9 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         icon: '🔍',
         shortcut: 'Ctrl+F',
         group: t('command_palette.group_navigation'),
-        action: () => { search.focus(); },
+        action: () => {
+          search.focus();
+        },
       },
       {
         id: 'help',
@@ -158,14 +178,18 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         icon: '❓',
         shortcut: '?',
         group: t('command_palette.group_navigation'),
-        action: () => { showHelpDialog({ onLoadSample: () => store.fromJSON(JSON.stringify(SAMPLE_ORG)) }); },
+        action: () => {
+          showHelpDialog({ onLoadSample: () => store.fromJSON(JSON.stringify(SAMPLE_ORG)) });
+        },
       },
       {
         id: 'theme',
         label: t('command_palette.item_theme'),
         icon: themeManager.getTheme() === 'dark' ? '☀️' : '🌙',
         group: t('command_palette.group_actions'),
-        action: () => { themeManager.toggle(); },
+        action: () => {
+          themeManager.toggle();
+        },
       },
       {
         id: 'new-chart',
@@ -214,7 +238,9 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
         label: t('command_palette.item_import'),
         icon: '📥',
         group: t('command_palette.group_actions'),
-        action: () => { importBtn.click(); },
+        action: () => {
+          importBtn.click();
+        },
       },
     ];
 
@@ -301,14 +327,17 @@ export function registerShortcuts(deps: ShortcutsDeps): ShortcutsResult {
 
   shortcuts.register({
     key: '?',
-    handler: () => showHelpDialog({ onLoadSample: () => store.fromJSON(JSON.stringify(SAMPLE_ORG)) }),
+    handler: () =>
+      showHelpDialog({ onLoadSample: () => store.fromJSON(JSON.stringify(SAMPLE_ORG)) }),
     description: t('shortcut.help'),
   });
 
   shortcuts.register({
     key: ',',
     ctrl: true,
-    handler: () => { settingsBtn.click(); },
+    handler: () => {
+      settingsBtn.click();
+    },
     description: t('shortcut.settings'),
   });
 

--- a/src/ui/help-dialog.ts
+++ b/src/ui/help-dialog.ts
@@ -35,6 +35,15 @@ interface HelpSection {
 function getHelpSections(): HelpSection[] {
   const sections: HelpSection[] = [
     {
+      titleKey: 'help.getting_started.title',
+      hasSampleOrg: true,
+      items: [
+        [t('help.getting_started.pan_zoom')],
+        [t('help.getting_started.right_click')],
+        [t('help.getting_started.sidebar')],
+      ],
+    },
+    {
       titleKey: 'help.shortcuts.title',
       type: 'shortcuts-grid',
       shortcuts: [
@@ -51,15 +60,6 @@ function getHelpSections(): HelpSection[] {
         { keys: ['Space'], desc: t('help.shortcuts.nav_multiselect') },
         { keys: ['Home', 'End'], desc: t('help.shortcuts.nav_home_end') },
         { keys: ['Shift+F10'], desc: t('help.shortcuts.nav_context_menu') },
-      ],
-    },
-    {
-      titleKey: 'help.getting_started.title',
-      hasSampleOrg: true,
-      items: [
-        [t('help.getting_started.pan_zoom')],
-        [t('help.getting_started.right_click')],
-        [t('help.getting_started.sidebar')],
       ],
     },
     {
@@ -293,9 +293,11 @@ function getHelpSections(): HelpSection[] {
   // Conditionally add company-specific import instructions from config
   const appConfig = getAppConfig();
   if (appConfig.importInstructions?.trim()) {
-    // Insert after the "Importing Data" section
-    const importIdx = sections.findIndex((s) => s.titleKey === 'help.importing.title');
-    const insertAt = importIdx >= 0 ? importIdx + 1 : sections.length;
+    // Insert after "Getting Started" section
+    const gettingStartedIdx = sections.findIndex(
+      (s) => s.titleKey === 'help.getting_started.title',
+    );
+    const insertAt = gettingStartedIdx >= 0 ? gettingStartedIdx + 1 : 0;
     sections.splice(insertAt, 0, {
       titleKey: 'import_instructions.help_title',
       type: 'markdown',

--- a/tests/ui/help-dialog-instructions.test.ts
+++ b/tests/ui/help-dialog-instructions.test.ts
@@ -55,4 +55,18 @@ describe('help dialog — import instructions section', () => {
     expect(body!.querySelector('h2')!.textContent).toBe('Guide');
     expect(body!.querySelectorAll('li').length).toBe(2);
   });
+
+  it('places import instructions as the second section (after Getting Started)', () => {
+    mockGetAppConfig.mockReturnValue({
+      importInstructions: '## Steps\n\n1. Do this',
+    });
+    showHelpDialog();
+    const headers = document.querySelectorAll('.help-section-header');
+    const texts = Array.from(headers).map((h) => h.textContent);
+
+    // First 3 sections should be: Getting Started, Import Instructions, Keyboard Shortcuts
+    expect(texts[0]).toContain('Getting Started');
+    expect(texts[1]).toContain('Import Instructions');
+    expect(texts[2]).toContain('Keyboard Shortcuts');
+  });
 });

--- a/tests/ui/help-dialog.test.ts
+++ b/tests/ui/help-dialog.test.ts
@@ -149,14 +149,14 @@ describe('showHelpDialog', () => {
     expect(firstSection.querySelector('.help-section-body')).not.toBeNull();
   });
 
-  it('Keyboard Shortcuts is the first section', () => {
+  it('Getting Started is the first section', () => {
     showHelpDialog();
     const sections = document.querySelectorAll('.help-section');
     const firstHeader = sections[0].querySelector('.help-section-header');
-    expect(firstHeader!.textContent).toContain('Keyboard Shortcuts');
+    expect(firstHeader!.textContent).toContain('Getting Started');
   });
 
-  it('Keyboard Shortcuts section is expanded by default', () => {
+  it('first section is expanded by default', () => {
     showHelpDialog();
     const sections = document.querySelectorAll('.help-section');
     expect(sections[0].classList.contains('open')).toBe(true);


### PR DESCRIPTION
## Summary

Reorders help dialog sections so the first 3 are:
1. Getting Started
2. Import Instructions (when enterprise config is present)
3. Keyboard Shortcuts

Previously Import Instructions appeared at position 7 (after Importing Data).

### Testing
- 2893 tests passing
- Updated existing ordering test + added new ordering assertion

## Sentinel
Pending review.
