### PR TITLE
fix(import-wizard): handle ChartBundle format in import wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.2] — 2026-05-13
+
+### Fixed
+
+- **Import wizard now handles `.arbol.json` chart bundles** — Exported charts can now be re-imported via the Import button. The wizard detects ChartBundle format, imports categories, level mappings, and saved versions. Previously it rejected these files with "Root node must have id, name, and title fields".
+
 ## [3.13.1] — 2026-05-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arbol",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arbol",
-      "version": "3.13.1",
+      "version": "3.13.2",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arbol",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "An interactive org chart editor for the browser",
   "directories": {
     "doc": "docs"

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1289,6 +1289,11 @@ const en: Record<string, string> = {
   'category_legend.toggle_aria': 'Toggle category legend',
   'import_wizard.file_selected': '\u2713 {name}',
   'import_wizard.json_root_error': 'Root node must have id, name, and title fields',
+  'import_wizard.bundle_unsupported_version': 'Unsupported chart bundle version: {version}',
+  'import_wizard.bundle_missing_chart': 'Invalid chart bundle: missing chart name or working tree',
+  'import_wizard.bundle_invalid_root':
+    'Invalid chart bundle: working tree root must have id, name, and title',
+  'import_wizard.bundle_info': 'Chart "{name}" with {count} saved version(s)',
   'settings_modal.tab.presets': 'Presets',
   'settings_modal.tab.layout': 'Layout',
   'settings_modal.tab.typography': 'Typography',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1245,6 +1245,13 @@ const es: Record<string, string> = {
   'category_legend.toggle_aria': 'Alternar leyenda de categorías',
   'import_wizard.file_selected': '\u2713 {name}',
   'import_wizard.json_root_error': 'El nodo raíz debe tener campos id, nombre y cargo',
+  'import_wizard.bundle_unsupported_version':
+    'Versión de paquete de organigrama no soportada: {version}',
+  'import_wizard.bundle_missing_chart':
+    'Paquete de organigrama inválido: falta el nombre o el árbol de trabajo',
+  'import_wizard.bundle_invalid_root':
+    'Paquete de organigrama inválido: el nodo raíz debe tener id, nombre y cargo',
+  'import_wizard.bundle_info': 'Organigrama "{name}" con {count} versión(es) guardada(s)',
   'settings_modal.tab.presets': 'Preajustes',
   'settings_modal.tab.layout': 'Disposición',
   'settings_modal.tab.typography': 'Tipografía',

--- a/src/main.ts
+++ b/src/main.ts
@@ -381,10 +381,12 @@ async function main(): Promise<void> {
       try {
         // ChartBundle import — delegate to extracted handler
         if (wizardState.bundle) {
-          const chart = await importBundle(wizardState.bundle, wizardState.destination ?? 'new', {
-            chartStore,
-            showConfirmDialog,
-          });
+          const chart = await importBundle(
+            wizardState.bundle,
+            wizardState.destination ?? 'new',
+            { chartStore, showConfirmDialog },
+            wizardState.chartName,
+          );
           if (!chart) return;
           await chartEditor.refresh();
           store.replaceTree(chart.workingTree);

--- a/src/main.ts
+++ b/src/main.ts
@@ -382,15 +382,25 @@ async function main(): Promise<void> {
         if (wizardState.bundle) {
           let chart;
           if (wizardState.destination === 'replace') {
+            const wouldReplace = await chartStore.wouldReplaceLevelMappings(wizardState.bundle);
+            if (wouldReplace) {
+              const proceed = await showConfirmDialog({
+                title: t('dialog.replace_mappings.title'),
+                message: t('dialog.replace_mappings.message'),
+                confirmLabel: t('dialog.replace_mappings.confirm'),
+                cancelLabel: t('dialog.replace_mappings.cancel'),
+                danger: true,
+              });
+              if (!proceed) return;
+            }
             chart = await chartStore.importChartReplaceCurrent(wizardState.bundle);
           } else {
             chart = await chartStore.importChartAsNew(wizardState.bundle);
           }
           await chartEditor.refresh();
           store.replaceTree(chart.workingTree);
-          if (chart.categories.length > 0) {
-            categoryStore.replaceAll(chart.categories);
-          }
+          categoryStore.replaceAll(chart.categories);
+          levelStore.loadFromChart(chart);
           chartNameHeader.setName(chart.name);
           chartNameHeader.setDirty(false);
           rerender();

--- a/src/main.ts
+++ b/src/main.ts
@@ -378,6 +378,31 @@ async function main(): Promise<void> {
     onComplete: async () => {
       if (!wizardState.tree) return;
       try {
+        // ChartBundle import — delegate to chartStore for full bundle handling
+        if (wizardState.bundle) {
+          let chart;
+          if (wizardState.destination === 'replace') {
+            chart = await chartStore.importChartReplaceCurrent(wizardState.bundle);
+          } else {
+            chart = await chartStore.importChartAsNew(wizardState.bundle);
+          }
+          await chartEditor.refresh();
+          store.replaceTree(chart.workingTree);
+          if (chart.categories.length > 0) {
+            categoryStore.replaceAll(chart.categories);
+          }
+          chartNameHeader.setName(chart.name);
+          chartNameHeader.setDirty(false);
+          rerender();
+          renderer.getZoomManager()?.fitToContent();
+          announce(t('announce.chart_switched', { name: chart.name }));
+          importWizard.close();
+          wizardState = {};
+          showToast(t('footer.imported'), 'success');
+          return;
+        }
+
+        // Raw tree import (JSON/CSV)
         let finalTree = wizardState.tree;
         if (wizardState.nameNormalization || wizardState.titleNormalization) {
           const { normalizeTreeText } = await import('./utils/text-normalize');
@@ -390,9 +415,7 @@ async function main(): Promise<void> {
         if (wizardState.destination === 'new' && wizardState.chartName) {
           const chart = await chartStore.createChartFromTree(wizardState.chartName, finalTree);
           await chartStore.saveVersion(t('import_wizard.original_version'), chart.workingTree);
-          // Ensure sidebar chart list reflects the new active chart before continuing
           await chartEditor.refresh();
-          // Switch the live OrgStore to the new chart's tree
           store.replaceTree(chart.workingTree);
           if (chart.categories.length > 0) {
             categoryStore.replaceAll(chart.categories);

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ import {
   renderPreviewStep,
   renderImportStep,
 } from './ui/import-wizard-steps';
+import { importBundle } from './ui/bundle-import-handler';
 import { registerShortcuts } from './init/shortcuts-handler';
 import type { ChartRecord } from './types';
 import { AnalyticsDrawer } from './ui/analytics-drawer';
@@ -378,25 +379,13 @@ async function main(): Promise<void> {
     onComplete: async () => {
       if (!wizardState.tree) return;
       try {
-        // ChartBundle import — delegate to chartStore for full bundle handling
+        // ChartBundle import — delegate to extracted handler
         if (wizardState.bundle) {
-          let chart;
-          if (wizardState.destination === 'replace') {
-            const wouldReplace = await chartStore.wouldReplaceLevelMappings(wizardState.bundle);
-            if (wouldReplace) {
-              const proceed = await showConfirmDialog({
-                title: t('dialog.replace_mappings.title'),
-                message: t('dialog.replace_mappings.message'),
-                confirmLabel: t('dialog.replace_mappings.confirm'),
-                cancelLabel: t('dialog.replace_mappings.cancel'),
-                danger: true,
-              });
-              if (!proceed) return;
-            }
-            chart = await chartStore.importChartReplaceCurrent(wizardState.bundle);
-          } else {
-            chart = await chartStore.importChartAsNew(wizardState.bundle);
-          }
+          const chart = await importBundle(wizardState.bundle, wizardState.destination ?? 'new', {
+            chartStore,
+            showConfirmDialog,
+          });
+          if (!chart) return;
           await chartEditor.refresh();
           store.replaceTree(chart.workingTree);
           categoryStore.replaceAll(chart.categories);

--- a/src/ui/bundle-import-handler.ts
+++ b/src/ui/bundle-import-handler.ts
@@ -1,0 +1,42 @@
+import type { ChartBundle, ChartRecord } from '../types';
+import type { ChartStore } from '../store/chart-store';
+import { t } from '../i18n';
+
+export interface BundleImportDeps {
+  chartStore: ChartStore;
+  showConfirmDialog: (opts: {
+    title: string;
+    message: string;
+    confirmLabel: string;
+    cancelLabel: string;
+    danger: boolean;
+  }) => Promise<boolean>;
+}
+
+/**
+ * Handles the chart-store side of a bundle import: confirmation dialogs
+ * for destructive replace and delegation to the appropriate chartStore method.
+ *
+ * Returns the imported ChartRecord, or null if the user cancelled.
+ */
+export async function importBundle(
+  bundle: ChartBundle,
+  destination: 'new' | 'replace',
+  deps: BundleImportDeps,
+): Promise<ChartRecord | null> {
+  if (destination === 'replace') {
+    const wouldReplace = await deps.chartStore.wouldReplaceLevelMappings(bundle);
+    if (wouldReplace) {
+      const proceed = await deps.showConfirmDialog({
+        title: t('dialog.replace_mappings.title'),
+        message: t('dialog.replace_mappings.message'),
+        confirmLabel: t('dialog.replace_mappings.confirm'),
+        cancelLabel: t('dialog.replace_mappings.cancel'),
+        danger: true,
+      });
+      if (!proceed) return null;
+    }
+    return deps.chartStore.importChartReplaceCurrent(bundle);
+  }
+  return deps.chartStore.importChartAsNew(bundle);
+}

--- a/src/ui/bundle-import-handler.ts
+++ b/src/ui/bundle-import-handler.ts
@@ -17,15 +17,24 @@ export interface BundleImportDeps {
  * Handles the chart-store side of a bundle import: confirmation dialogs
  * for destructive replace and delegation to the appropriate chartStore method.
  *
+ * When chartName is provided, overrides the bundle's chart name (without
+ * mutating the original bundle object).
+ *
  * Returns the imported ChartRecord, or null if the user cancelled.
  */
 export async function importBundle(
   bundle: ChartBundle,
   destination: 'new' | 'replace',
   deps: BundleImportDeps,
+  chartName?: string,
 ): Promise<ChartRecord | null> {
+  const effectiveBundle =
+    chartName && chartName !== bundle.chart.name
+      ? { ...bundle, chart: { ...bundle.chart, name: chartName } }
+      : bundle;
+
   if (destination === 'replace') {
-    const wouldReplace = await deps.chartStore.wouldReplaceLevelMappings(bundle);
+    const wouldReplace = await deps.chartStore.wouldReplaceLevelMappings(effectiveBundle);
     if (wouldReplace) {
       const proceed = await deps.showConfirmDialog({
         title: t('dialog.replace_mappings.title'),
@@ -36,7 +45,7 @@ export async function importBundle(
       });
       if (!proceed) return null;
     }
-    return deps.chartStore.importChartReplaceCurrent(bundle);
+    return deps.chartStore.importChartReplaceCurrent(effectiveBundle);
   }
-  return deps.chartStore.importChartAsNew(bundle);
+  return deps.chartStore.importChartAsNew(effectiveBundle);
 }

--- a/src/ui/bundle-import-handler.ts
+++ b/src/ui/bundle-import-handler.ts
@@ -17,8 +17,9 @@ export interface BundleImportDeps {
  * Handles the chart-store side of a bundle import: confirmation dialogs
  * for destructive replace and delegation to the appropriate chartStore method.
  *
- * When chartName is provided, overrides the bundle's chart name (without
- * mutating the original bundle object).
+ * For "new" imports, chartName overrides the bundle's chart name (without
+ * mutating the original bundle object). For "replace" imports, chartName
+ * is ignored since the existing chart retains its name.
  *
  * Returns the imported ChartRecord, or null if the user cancelled.
  */
@@ -28,8 +29,9 @@ export async function importBundle(
   deps: BundleImportDeps,
   chartName?: string,
 ): Promise<ChartRecord | null> {
+  // chartName override only applies to new chart imports
   const effectiveBundle =
-    chartName && chartName !== bundle.chart.name
+    destination === 'new' && chartName && chartName !== bundle.chart.name
       ? { ...bundle, chart: { ...bundle.chart, name: chartName } }
       : bundle;
 

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -422,9 +422,17 @@ export function renderPreviewStep(
 
     container.appendChild(tableWrap);
 
-    // Normalization dropdowns — re-render sample on change
-    renderNormDropdown(container, 'name', t('import_wizard.norm_label_name'), state, renderRows);
-    renderNormDropdown(container, 'title', t('import_wizard.norm_label_title'), state, renderRows);
+    // Normalization dropdowns — skip for bundles (data is already finalized)
+    if (!state.bundle) {
+      renderNormDropdown(container, 'name', t('import_wizard.norm_label_name'), state, renderRows);
+      renderNormDropdown(
+        container,
+        'title',
+        t('import_wizard.norm_label_title'),
+        state,
+        renderRows,
+      );
+    }
 
     onReady(true);
   } catch (e) {

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -302,6 +302,7 @@ export function renderPreviewStep(
         state.tree = root;
         state.nodeCount = countNodes(root);
       } else {
+        state.bundle = undefined;
         if (!parsed.id || !parsed.name || !parsed.title) {
           throw new Error(t('import_wizard.json_root_error'));
         }
@@ -309,6 +310,7 @@ export function renderPreviewStep(
         state.nodeCount = countNodes(parsed);
       }
     } else {
+      state.bundle = undefined;
       const result = parseCsvToTree(state.rawText!, state.mapping);
       state.tree = result.tree;
       state.nodeCount = result.nodeCount;

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -303,6 +303,8 @@ export function renderPreviewStep(
         state.nodeCount = countNodes(root);
       } else {
         state.bundle = undefined;
+        state.destination = undefined;
+        state.chartName = undefined;
         if (!parsed.id || !parsed.name || !parsed.title) {
           throw new Error(t('import_wizard.json_root_error'));
         }
@@ -311,6 +313,8 @@ export function renderPreviewStep(
       }
     } else {
       state.bundle = undefined;
+      state.destination = undefined;
+      state.chartName = undefined;
       const result = parseCsvToTree(state.rawText!, state.mapping);
       state.tree = result.tree;
       state.nodeCount = result.nodeCount;

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -1,4 +1,10 @@
-import type { ColumnMapping, MappingPreset, OrgNode, TextNormalization } from '../types';
+import type {
+  ChartBundle,
+  ColumnMapping,
+  MappingPreset,
+  OrgNode,
+  TextNormalization,
+} from '../types';
 import { t } from '../i18n';
 import { showToast } from './toast';
 import { extractHeaders, parseCsvToTree } from '../utils/csv-parser';
@@ -21,6 +27,7 @@ export interface WizardState {
   titleNormalization?: TextNormalization;
   destination?: 'new' | 'replace';
   chartName?: string;
+  bundle?: ChartBundle;
 }
 
 // ─── Step 1: Source ──────────────────────────────────────────────────
@@ -273,11 +280,34 @@ export function renderPreviewStep(
   try {
     if (state.format === 'JSON') {
       const parsed = JSON.parse(state.rawText!);
-      if (!parsed.id || !parsed.name || !parsed.title) {
-        throw new Error('Root node must have id, name, and title fields');
+
+      if (parsed.format === 'arbol-chart') {
+        // ChartBundle format
+        const bundle = parsed as ChartBundle;
+        if (bundle.version !== 1) {
+          throw new Error(
+            t('import_wizard.bundle_unsupported_version', {
+              version: String(bundle.version),
+            }),
+          );
+        }
+        if (!bundle.chart?.name || !bundle.chart?.workingTree) {
+          throw new Error(t('import_wizard.bundle_missing_chart'));
+        }
+        const root = bundle.chart.workingTree;
+        if (!root.id || !root.name || !root.title) {
+          throw new Error(t('import_wizard.bundle_invalid_root'));
+        }
+        state.bundle = bundle;
+        state.tree = root;
+        state.nodeCount = countNodes(root);
+      } else {
+        if (!parsed.id || !parsed.name || !parsed.title) {
+          throw new Error(t('import_wizard.json_root_error'));
+        }
+        state.tree = parsed as OrgNode;
+        state.nodeCount = countNodes(parsed);
       }
-      state.tree = parsed as OrgNode;
-      state.nodeCount = countNodes(parsed);
     } else {
       const result = parseCsvToTree(state.rawText!, state.mapping);
       state.tree = result.tree;
@@ -291,6 +321,18 @@ export function renderPreviewStep(
       format: state.format!,
     });
     container.appendChild(success);
+
+    // Show bundle version info if applicable
+    if (state.bundle) {
+      const versionCount = state.bundle.versions?.length ?? 0;
+      const info = document.createElement('p');
+      info.className = 'wizard-bundle-info';
+      info.textContent = t('import_wizard.bundle_info', {
+        name: state.bundle.chart.name,
+        count: String(versionCount),
+      });
+      container.appendChild(info);
+    }
 
     // Sample table showing first 5 people
     const sampleNodes = flattenTree(state.tree!).slice(0, 5);
@@ -454,7 +496,14 @@ export function renderImportStep(
   group.className = 'wizard-radio-group';
   group.setAttribute('role', 'radiogroup');
 
-  if (!state.destination) state.destination = 'replace';
+  if (!state.destination) {
+    state.destination = state.bundle ? 'new' : 'replace';
+  }
+
+  // Pre-fill chart name from bundle
+  if (state.bundle && !state.chartName) {
+    state.chartName = state.bundle.chart.name;
+  }
 
   const replaceRadio = createRadioOption(
     'replace',

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -301,6 +301,8 @@ export function renderPreviewStep(
         state.bundle = bundle;
         state.tree = root;
         state.nodeCount = countNodes(root);
+        state.destination = undefined;
+        state.chartName = undefined;
       } else {
         state.bundle = undefined;
         state.destination = undefined;

--- a/tests/ui/bundle-import-handler.test.ts
+++ b/tests/ui/bundle-import-handler.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import { setLocale } from '../../src/i18n';
+import en from '../../src/i18n/en';
+import { importBundle, BundleImportDeps } from '../../src/ui/bundle-import-handler';
+import type { ChartBundle, ChartRecord } from '../../src/types';
+
+beforeAll(() => {
+  setLocale('en', en);
+});
+
+function makeBundle(overrides?: Partial<ChartBundle>): ChartBundle {
+  return {
+    format: 'arbol-chart',
+    version: 1,
+    chart: {
+      name: 'Test Chart',
+      workingTree: { id: '1', name: 'Alice', title: 'CEO' },
+      categories: [{ id: 'cat-1', label: 'Engineering', color: '#3b82f6' }],
+    },
+    versions: [
+      {
+        name: 'v1',
+        createdAt: '2025-01-01T00:00:00Z',
+        tree: { id: '1', name: 'Alice', title: 'CEO' },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeChart(): ChartRecord {
+  return {
+    id: 'chart-1',
+    name: 'Test Chart',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    workingTree: { id: '1', name: 'Alice', title: 'CEO' },
+    categories: [{ id: 'cat-1', label: 'Engineering', color: '#3b82f6' }],
+  };
+}
+
+function makeDeps(
+  overrides?: Partial<{
+    wouldReplace: boolean;
+    confirmResult: boolean;
+    chart: ChartRecord;
+  }>,
+): BundleImportDeps & {
+  importChartAsNew: ReturnType<typeof vi.fn>;
+  importChartReplaceCurrent: ReturnType<typeof vi.fn>;
+  showConfirmDialog: ReturnType<typeof vi.fn>;
+  wouldReplaceLevelMappings: ReturnType<typeof vi.fn>;
+} {
+  const chart = overrides?.chart ?? makeChart();
+  const importChartAsNew = vi.fn().mockResolvedValue(chart);
+  const importChartReplaceCurrent = vi.fn().mockResolvedValue(chart);
+  const wouldReplaceLevelMappings = vi.fn().mockResolvedValue(overrides?.wouldReplace ?? false);
+  const showConfirmDialog = vi.fn().mockResolvedValue(overrides?.confirmResult ?? true);
+
+  return {
+    importChartAsNew,
+    importChartReplaceCurrent,
+    wouldReplaceLevelMappings,
+    showConfirmDialog,
+    chartStore: {
+      importChartAsNew,
+      importChartReplaceCurrent,
+      wouldReplaceLevelMappings,
+    } as unknown as BundleImportDeps['chartStore'],
+  };
+}
+
+describe('importBundle', () => {
+  it('calls importChartAsNew for destination "new"', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps();
+    const result = await importBundle(bundle, 'new', deps);
+    expect(deps.importChartAsNew).toHaveBeenCalledWith(bundle);
+    expect(deps.importChartReplaceCurrent).not.toHaveBeenCalled();
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe('Test Chart');
+  });
+
+  it('calls importChartReplaceCurrent for destination "replace" when no mapping conflict', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps({ wouldReplace: false });
+    const result = await importBundle(bundle, 'replace', deps);
+    expect(deps.wouldReplaceLevelMappings).toHaveBeenCalledWith(bundle);
+    expect(deps.showConfirmDialog).not.toHaveBeenCalled();
+    expect(deps.importChartReplaceCurrent).toHaveBeenCalledWith(bundle);
+    expect(result).not.toBeNull();
+  });
+
+  it('shows confirmation dialog when replacing level mappings', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps({ wouldReplace: true, confirmResult: true });
+    const result = await importBundle(bundle, 'replace', deps);
+    expect(deps.showConfirmDialog).toHaveBeenCalledOnce();
+    expect(deps.showConfirmDialog).toHaveBeenCalledWith(expect.objectContaining({ danger: true }));
+    expect(deps.importChartReplaceCurrent).toHaveBeenCalledWith(bundle);
+    expect(result).not.toBeNull();
+  });
+
+  it('returns null when user cancels replace confirmation', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps({ wouldReplace: true, confirmResult: false });
+    const result = await importBundle(bundle, 'replace', deps);
+    expect(deps.showConfirmDialog).toHaveBeenCalledOnce();
+    expect(deps.importChartReplaceCurrent).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+
+  it('does not show confirmation for destination "new"', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps({ wouldReplace: true });
+    await importBundle(bundle, 'new', deps);
+    expect(deps.wouldReplaceLevelMappings).not.toHaveBeenCalled();
+    expect(deps.showConfirmDialog).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/bundle-import-handler.test.ts
+++ b/tests/ui/bundle-import-handler.test.ts
@@ -117,4 +117,22 @@ describe('importBundle', () => {
     expect(deps.wouldReplaceLevelMappings).not.toHaveBeenCalled();
     expect(deps.showConfirmDialog).not.toHaveBeenCalled();
   });
+
+  it('overrides bundle chart name with user-provided chartName', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps();
+    await importBundle(bundle, 'new', deps, 'Custom Name');
+    const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
+    expect(passedBundle.chart.name).toBe('Custom Name');
+    // Original bundle should not be mutated
+    expect(bundle.chart.name).toBe('Test Chart');
+  });
+
+  it('uses bundle chart name when no chartName override provided', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps();
+    await importBundle(bundle, 'new', deps);
+    const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
+    expect(passedBundle.chart.name).toBe('Test Chart');
+  });
 });

--- a/tests/ui/bundle-import-handler.test.ts
+++ b/tests/ui/bundle-import-handler.test.ts
@@ -135,4 +135,12 @@ describe('importBundle', () => {
     const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
     expect(passedBundle.chart.name).toBe('Test Chart');
   });
+
+  it('ignores chartName override for replace imports', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps({ wouldReplace: false });
+    await importBundle(bundle, 'replace', deps, 'Ignored Name');
+    const passedBundle = deps.importChartReplaceCurrent.mock.calls[0][0] as ChartBundle;
+    expect(passedBundle.chart.name).toBe('Test Chart');
+  });
 });

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -561,6 +561,13 @@ describe('renderPreviewStep — ChartBundle', () => {
     expect(info!.textContent).toContain('version');
   });
 
+  it('hides normalization dropdowns for bundle imports', () => {
+    const state: WizardState = { format: 'JSON', rawText: makeBundle() };
+    renderPreviewStep(container, state, vi.fn());
+    const selects = container.querySelectorAll('.wizard-field select');
+    expect(selects.length).toBe(0);
+  });
+
   it('shows error for unsupported bundle version', () => {
     const state: WizardState = {
       format: 'JSON',

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -224,7 +224,9 @@ describe('renderPreviewStep', () => {
     const state: WizardState = {
       format: 'JSON',
       rawText: JSON.stringify({
-        id: '1', name: 'Alice', title: 'CEO',
+        id: '1',
+        name: 'Alice',
+        title: 'CEO',
         children: [{ id: '2', name: 'Bob', title: 'VP' }],
       }),
     };
@@ -238,7 +240,9 @@ describe('renderPreviewStep', () => {
     const state: WizardState = {
       format: 'JSON',
       rawText: JSON.stringify({
-        id: '1', name: 'Alice', title: 'CEO',
+        id: '1',
+        name: 'Alice',
+        title: 'CEO',
         children: [{ id: '2', name: 'Bob', title: 'VP' }],
       }),
     };
@@ -454,5 +458,143 @@ describe('renderImportStep', () => {
     renderImportStep(container, state, vi.fn());
     const nameInput = container.querySelector('.wizard-field input') as HTMLInputElement;
     expect(nameInput.placeholder).toBe('My Org Chart');
+  });
+
+  it('defaults to new chart and pre-fills name when bundle is set', () => {
+    const bundle = {
+      format: 'arbol-chart' as const,
+      version: 1 as const,
+      chart: {
+        name: 'Engineering Org',
+        workingTree: { id: '1', name: 'Alice', title: 'CEO' },
+        categories: [],
+      },
+      versions: [],
+    };
+    const state: WizardState = { nodeCount: 3, format: 'JSON', bundle };
+    renderImportStep(container, state, vi.fn());
+    expect(state.destination).toBe('new');
+    expect(state.chartName).toBe('Engineering Org');
+    const newRadio = container.querySelectorAll('.wizard-radio')[1];
+    expect(newRadio.classList.contains('selected')).toBe(true);
+    const nameInput = container.querySelector('.wizard-field input') as HTMLInputElement;
+    expect(nameInput.value).toBe('Engineering Org');
+    const nameField = container.querySelectorAll('.wizard-field')[0] as HTMLElement;
+    expect(nameField.style.display).toBe('');
+  });
+});
+
+describe('renderPreviewStep — ChartBundle', () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  function makeBundle(overrides?: Record<string, unknown>) {
+    return JSON.stringify({
+      format: 'arbol-chart',
+      version: 1,
+      chart: {
+        name: 'My Team',
+        workingTree: {
+          id: '1',
+          name: 'Alice',
+          title: 'CEO',
+          children: [{ id: '2', name: 'Bob', title: 'VP' }],
+        },
+        categories: [],
+      },
+      versions: [
+        {
+          name: 'v1',
+          createdAt: '2025-01-01T00:00:00Z',
+          tree: { id: '1', name: 'Alice', title: 'CEO' },
+        },
+      ],
+      ...overrides,
+    });
+  }
+
+  it('parses ChartBundle JSON and shows success with version count', () => {
+    const state: WizardState = { format: 'JSON', rawText: makeBundle() };
+    renderPreviewStep(container, state, vi.fn());
+    const success = container.querySelector('.wizard-success');
+    expect(success).not.toBeNull();
+    expect(success!.textContent).toContain('2 people');
+  });
+
+  it('stores bundle in state', () => {
+    const state: WizardState = { format: 'JSON', rawText: makeBundle() };
+    renderPreviewStep(container, state, vi.fn());
+    expect(state.bundle).toBeDefined();
+    expect(state.bundle!.format).toBe('arbol-chart');
+    expect(state.bundle!.chart.name).toBe('My Team');
+  });
+
+  it('extracts workingTree into state.tree', () => {
+    const state: WizardState = { format: 'JSON', rawText: makeBundle() };
+    renderPreviewStep(container, state, vi.fn());
+    expect(state.tree).toBeDefined();
+    expect(state.tree!.name).toBe('Alice');
+    expect(state.nodeCount).toBe(2);
+  });
+
+  it('calls onReady(true) for valid bundle', () => {
+    const state: WizardState = { format: 'JSON', rawText: makeBundle() };
+    const onReady = vi.fn();
+    renderPreviewStep(container, state, onReady);
+    expect(onReady).toHaveBeenCalledWith(true);
+  });
+
+  it('shows version info in success message', () => {
+    const state: WizardState = { format: 'JSON', rawText: makeBundle() };
+    renderPreviewStep(container, state, vi.fn());
+    const info = container.querySelector('.wizard-bundle-info');
+    expect(info).not.toBeNull();
+    expect(info!.textContent).toContain('1');
+    expect(info!.textContent).toContain('version');
+  });
+
+  it('shows error for unsupported bundle version', () => {
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: makeBundle({ version: 99 }),
+    };
+    const onReady = vi.fn();
+    renderPreviewStep(container, state, onReady);
+    const error = container.querySelector('.wizard-error');
+    expect(error).not.toBeNull();
+    expect(error!.textContent).toContain('Unsupported');
+    expect(onReady).toHaveBeenCalledWith(false);
+  });
+
+  it('shows error when bundle is missing chart data', () => {
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: JSON.stringify({ format: 'arbol-chart', version: 1 }),
+    };
+    const onReady = vi.fn();
+    renderPreviewStep(container, state, onReady);
+    const error = container.querySelector('.wizard-error');
+    expect(error).not.toBeNull();
+    expect(onReady).toHaveBeenCalledWith(false);
+  });
+
+  it('handles bundle with zero versions', () => {
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: makeBundle({ versions: [] }),
+    };
+    renderPreviewStep(container, state, vi.fn());
+    const success = container.querySelector('.wizard-success');
+    expect(success).not.toBeNull();
+    expect(state.bundle).toBeDefined();
+    expect(state.bundle!.versions).toHaveLength(0);
   });
 });

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -586,6 +586,28 @@ describe('renderPreviewStep — ChartBundle', () => {
     expect(onReady).toHaveBeenCalledWith(false);
   });
 
+  it('shows error when bundle working tree root lacks required fields', () => {
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: JSON.stringify({
+        format: 'arbol-chart',
+        version: 1,
+        chart: {
+          name: 'Bad Chart',
+          workingTree: { foo: 'bar' },
+          categories: [],
+        },
+        versions: [],
+      }),
+    };
+    const onReady = vi.fn();
+    renderPreviewStep(container, state, onReady);
+    const error = container.querySelector('.wizard-error');
+    expect(error).not.toBeNull();
+    expect(error!.textContent).toContain('working tree root');
+    expect(onReady).toHaveBeenCalledWith(false);
+  });
+
   it('handles bundle with zero versions', () => {
     const state: WizardState = {
       format: 'JSON',

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -597,4 +597,39 @@ describe('renderPreviewStep — ChartBundle', () => {
     expect(state.bundle).toBeDefined();
     expect(state.bundle!.versions).toHaveLength(0);
   });
+
+  it('clears stale bundle when switching to plain JSON', () => {
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: makeBundle(),
+    };
+    renderPreviewStep(container, state, vi.fn());
+    expect(state.bundle).toBeDefined();
+
+    // Now switch to plain OrgNode JSON — bundle should be cleared by renderPreviewStep
+    state.rawText = JSON.stringify({ id: '1', name: 'Alice', title: 'CEO' });
+    renderPreviewStep(container, state, vi.fn());
+    expect(state.bundle).toBeUndefined();
+  });
+
+  it('clears stale bundle when switching to CSV', () => {
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: makeBundle(),
+    };
+    renderPreviewStep(container, state, vi.fn());
+    expect(state.bundle).toBeDefined();
+
+    // Now switch to CSV
+    state.format = 'CSV';
+    state.rawText = 'name,title,manager_name\nAlice,CEO,\nBob,VP,Alice\n';
+    state.mapping = {
+      name: 'name',
+      title: 'title',
+      parentRef: 'manager_name',
+      parentRefType: 'name',
+    };
+    renderPreviewStep(container, state, vi.fn());
+    expect(state.bundle).toBeUndefined();
+  });
 });

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -628,10 +628,16 @@ describe('renderPreviewStep — ChartBundle', () => {
     renderPreviewStep(container, state, vi.fn());
     expect(state.bundle).toBeDefined();
 
-    // Now switch to plain OrgNode JSON — bundle should be cleared by renderPreviewStep
+    // Simulate step 4 having set bundle-derived defaults
+    state.destination = 'new';
+    state.chartName = 'My Team';
+
+    // Now switch to plain OrgNode JSON — bundle-derived state should be cleared
     state.rawText = JSON.stringify({ id: '1', name: 'Alice', title: 'CEO' });
     renderPreviewStep(container, state, vi.fn());
     expect(state.bundle).toBeUndefined();
+    expect(state.destination).toBeUndefined();
+    expect(state.chartName).toBeUndefined();
   });
 
   it('clears stale bundle when switching to CSV', () => {


### PR DESCRIPTION
## Summary

The import wizard now detects and correctly handles `.arbol.json` ChartBundle files. Previously, importing an exported chart via the Import button failed with "Root node must have id, name, and title fields" because the wizard only accepted raw OrgNode JSON.

## Changes

- `src/ui/import-wizard-steps.ts` — Added `bundle?: ChartBundle` to `WizardState`. `renderPreviewStep` now detects ChartBundle format, validates the bundle, and extracts the working tree. `renderImportStep` defaults to "Create new chart" and pre-fills the chart name when a bundle is detected.
- `src/main.ts` — `onComplete` handler delegates to `chartStore.importChartAsNew()` / `importChartReplaceCurrent()` for bundle imports, properly handling categories, versions, and level mappings.
- `src/i18n/en.ts` + `es.ts` — Added i18n strings for bundle validation errors and info messages.
- `tests/ui/import-wizard-steps.test.ts` — 9 new tests covering ChartBundle detection, validation, and import step pre-filling.

## TDD Compliance

test(import-wizard) commit before fix(import-wizard) commit.

Sentinel review pending.
