### PR TITLE
docs(sentinel): set coverage threshold to 80%

### DIFF
--- a/docs/SENTINEL.md
+++ b/docs/SENTINEL.md
@@ -153,7 +153,7 @@ Status: APPROVED | REJECTED
 - Tests exist & meaningful: ✅/❌ (evidence)
 - Test-first history verified: ✅/❌ (evidence)
 - Full suite green on SHA: ✅/❌ (evidence)
-- Coverage: {{X}}% (threshold {{COVERAGE_THRESHOLD}}%) ✅/❌ (evidence)
+- Coverage: {{X}}% (threshold 80%) ✅/❌ (evidence)
 
 ### Phase 2 — Execution Log
 | Dim | Tool Call | Agent ID / Ref | Status |


### PR DESCRIPTION
Replace unresolved template variable \{{COVERAGE_THRESHOLD}}\ with \80\ in the Sentinel report template, matching the existing threshold defined on line 61.

This is a HUMAN REQUIRED change per AGENTS.md, approved by user.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>