### PR TITLE
fix: improve backup restore resilience

### DIFF
--- a/src/store/backup-manager.ts
+++ b/src/store/backup-manager.ts
@@ -197,11 +197,7 @@ export async function restoreFullReplace(
 
   // Stage 2: Snapshot existing data for rollback
   const existingCharts = await db.getAllCharts();
-  const existingVersions: VersionRecord[] = [];
-  for (const chart of existingCharts) {
-    const versions = await db.getVersionsByChart(chart.id);
-    existingVersions.push(...versions);
-  }
+  const existingVersions = await db.getAllVersions();
   const existingLSValues: Record<string, string | null> = {};
   for (const key of ALL_ARBOL_LS_KEYS) {
     existingLSValues[key] = storage.getItem(key);
@@ -229,33 +225,35 @@ export async function restoreFullReplace(
 
     restoreLocalStorage(backup, storage);
   } catch (error) {
+    const rollbackErrors: unknown[] = [];
+
     // Best-effort rollback: attempt all recovery steps, never abort mid-recovery
     for (const id of writtenVersionIds) {
       try {
         await db.deleteVersion(id);
-      } catch {
-        /* best-effort */
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
       }
     }
     for (const id of writtenChartIds) {
       try {
         await db.deleteChart(id);
-      } catch {
-        /* best-effort */
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
       }
     }
     for (const chart of existingCharts) {
       try {
         await db.putChart(chart);
-      } catch {
-        /* best-effort */
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
       }
     }
     for (const version of existingVersions) {
       try {
         await db.putVersion(version);
-      } catch {
-        /* best-effort */
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
       }
     }
     for (const [key, value] of Object.entries(existingLSValues)) {
@@ -265,10 +263,19 @@ export async function restoreFullReplace(
         } else {
           storage.removeItem(key);
         }
-      } catch {
-        /* best-effort */
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
       }
     }
+
+    if (rollbackErrors.length > 0) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `${message} (rollback also failed: ${rollbackErrors.length} recovery step(s) failed)`,
+        { cause: error },
+      );
+    }
+
     throw error;
   }
 }

--- a/src/store/chart-db.ts
+++ b/src/store/chart-db.ts
@@ -132,7 +132,9 @@ export class ChartDB {
 
       request.onsuccess = () => {
         const versions = request.result as VersionRecord[];
-        versions.sort((a, b) => (b.createdAt > a.createdAt ? 1 : b.createdAt < a.createdAt ? -1 : 0));
+        versions.sort((a, b) =>
+          b.createdAt > a.createdAt ? 1 : b.createdAt < a.createdAt ? -1 : 0,
+        );
         resolve(versions);
       };
 
@@ -140,6 +142,12 @@ export class ChartDB {
         reject(new Error(`Failed to get versions for chart ${chartId}: ${request.error?.message}`));
       };
     });
+  }
+
+  getAllVersions(): Promise<VersionRecord[]> {
+    return this.getAll<VersionRecord>(VERSIONS_STORE).then((versions) =>
+      versions.sort((a, b) => (b.createdAt > a.createdAt ? 1 : b.createdAt < a.createdAt ? -1 : 0)),
+    );
   }
 
   getVersion(id: string): Promise<VersionRecord | undefined> {
@@ -164,7 +172,8 @@ export class ChartDB {
     const db = this.requireDB();
     return new Promise((resolve, reject) => {
       const tx = db.transaction(VERSIONS_STORE, 'readwrite');
-      tx.onerror = () => reject(new Error(`Failed to delete versions for chart ${chartId}: ${tx.error?.message}`));
+      tx.onerror = () =>
+        reject(new Error(`Failed to delete versions for chart ${chartId}: ${tx.error?.message}`));
       tx.oncomplete = () => resolve();
 
       const index = tx.objectStore(VERSIONS_STORE).index('chartId');

--- a/tests/store/backup-manager.test.ts
+++ b/tests/store/backup-manager.test.ts
@@ -53,12 +53,17 @@ function makeVersion(id: string, chartId: string): VersionRecord {
   };
 }
 
-function createMockDB(charts: ChartRecord[] = [], versions: VersionRecord[] = []): ChartDB {
+type MockChartDB = ChartDB & {
+  getAllVersions: ReturnType<typeof vi.fn>;
+};
+
+function createMockDB(charts: ChartRecord[] = [], versions: VersionRecord[] = []): MockChartDB {
   const chartsMap = new Map(charts.map((c) => [c.id, { ...c }]));
   const versionsMap = new Map(versions.map((v) => [v.id, { ...v }]));
 
   return {
     getAllCharts: vi.fn(async () => [...chartsMap.values()]),
+    getAllVersions: vi.fn(async () => [...versionsMap.values()]),
     getChart: vi.fn(async (id: string) => chartsMap.get(id)),
     putChart: vi.fn(async (chart: ChartRecord) => {
       chartsMap.set(chart.id, chart);
@@ -80,7 +85,7 @@ function createMockDB(charts: ChartRecord[] = [], versions: VersionRecord[] = []
     }),
     _charts: chartsMap,
     _versions: versionsMap,
-  } as unknown as ChartDB;
+  } as unknown as MockChartDB;
 }
 
 function makeValidBackup(overrides?: Partial<ArbolBackup>): ArbolBackup {
@@ -523,6 +528,38 @@ describe('BackupManager', () => {
 
       // Despite e1 rollback failing, e2 should still have been attempted
       expect(putChartFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('includes rollback failure details in the restore error message', async () => {
+      const existing = [makeChart('e1', 'Existing')];
+      const existingVersions = [makeVersion('ve1', 'e1')];
+      const db = createMockDB(existing, existingVersions);
+      const storage = {
+        getItem: vi.fn(() => null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+      };
+
+      const putChartFn = db.putChart as ReturnType<typeof vi.fn>;
+      putChartFn
+        .mockRejectedValueOnce(new Error('write fail'))
+        .mockRejectedValueOnce(new Error('rollback restore failed'));
+
+      await expect(restoreFullReplace(db, makeValidBackup(), storage)).rejects.toThrow(
+        'write fail (rollback also failed: 1 recovery step(s) failed)',
+      );
+    });
+
+    it('snapshots existing versions with a single bulk read before restore', async () => {
+      const existing = [makeChart('e1', 'Existing'), makeChart('e2', 'Existing 2')];
+      const existingVersions = [makeVersion('ve1', 'e1'), makeVersion('ve2', 'e2')];
+      const db = createMockDB(existing, existingVersions);
+
+      await restoreFullReplace(db, makeValidBackup());
+
+      expect(db.getAllVersions).toHaveBeenCalledTimes(1);
+      expect(db.getVersionsByChart).not.toHaveBeenCalled();
     });
 
     it('rolls back on version write failure', async () => {

--- a/tests/store/chart-db.test.ts
+++ b/tests/store/chart-db.test.ts
@@ -97,9 +97,21 @@ describe('ChartDB', () => {
     });
 
     it('getAllCharts returns charts sorted by createdAt ascending', async () => {
-      const oldest = makeChart({ id: 'c-old', name: 'Oldest', createdAt: '2025-01-01T00:00:00.000Z' });
-      const middle = makeChart({ id: 'c-mid', name: 'Middle', createdAt: '2025-03-01T00:00:00.000Z' });
-      const newest = makeChart({ id: 'c-new', name: 'Newest', createdAt: '2025-06-01T00:00:00.000Z' });
+      const oldest = makeChart({
+        id: 'c-old',
+        name: 'Oldest',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      });
+      const middle = makeChart({
+        id: 'c-mid',
+        name: 'Middle',
+        createdAt: '2025-03-01T00:00:00.000Z',
+      });
+      const newest = makeChart({
+        id: 'c-new',
+        name: 'Newest',
+        createdAt: '2025-06-01T00:00:00.000Z',
+      });
 
       await db.putChart(oldest);
       await db.putChart(middle);
@@ -181,15 +193,55 @@ describe('ChartDB', () => {
     });
 
     it('getVersionsByChart returns versions sorted by createdAt descending', async () => {
-      const oldest = makeVersion({ id: 'v-old', chartId: 'chart-1', createdAt: '2025-01-01T00:00:00.000Z' });
-      const middle = makeVersion({ id: 'v-mid', chartId: 'chart-1', createdAt: '2025-03-01T00:00:00.000Z' });
-      const newest = makeVersion({ id: 'v-new', chartId: 'chart-1', createdAt: '2025-06-01T00:00:00.000Z' });
+      const oldest = makeVersion({
+        id: 'v-old',
+        chartId: 'chart-1',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      });
+      const middle = makeVersion({
+        id: 'v-mid',
+        chartId: 'chart-1',
+        createdAt: '2025-03-01T00:00:00.000Z',
+      });
+      const newest = makeVersion({
+        id: 'v-new',
+        chartId: 'chart-1',
+        createdAt: '2025-06-01T00:00:00.000Z',
+      });
 
       await db.putVersion(oldest);
       await db.putVersion(middle);
       await db.putVersion(newest);
 
       const versions = await db.getVersionsByChart('chart-1');
+      expect(versions).toHaveLength(3);
+      expect(versions[0].id).toBe('v-new');
+      expect(versions[1].id).toBe('v-mid');
+      expect(versions[2].id).toBe('v-old');
+    });
+
+    it('getAllVersions returns all versions sorted by createdAt descending', async () => {
+      const oldest = makeVersion({
+        id: 'v-old',
+        chartId: 'chart-a',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      });
+      const middle = makeVersion({
+        id: 'v-mid',
+        chartId: 'chart-b',
+        createdAt: '2025-03-01T00:00:00.000Z',
+      });
+      const newest = makeVersion({
+        id: 'v-new',
+        chartId: 'chart-a',
+        createdAt: '2025-06-01T00:00:00.000Z',
+      });
+
+      await db.putVersion(oldest);
+      await db.putVersion(middle);
+      await db.putVersion(newest);
+
+      const versions = await db.getAllVersions();
       expect(versions).toHaveLength(3);
       expect(versions[0].id).toBe('v-new');
       expect(versions[1].id).toBe('v-mid');
@@ -239,6 +291,11 @@ describe('ChartDB', () => {
     it('getAllCharts throws "Database not open" after close', () => {
       db.close();
       expect(() => db.getAllCharts()).toThrow('Database not open');
+    });
+
+    it('getAllVersions throws "Database not open" after close', () => {
+      db.close();
+      expect(() => db.getAllVersions()).toThrow('Database not open');
     });
 
     it('putChart throws "Database not open" after close', () => {
@@ -347,7 +404,10 @@ describe('ChartDB', () => {
       await db.putChart(chart);
 
       const newTree = makeTree({ name: 'Updated Root' });
-      await db.patchChart('chart-patch', { workingTree: newTree, updatedAt: '2025-06-15T00:00:00.000Z' });
+      await db.patchChart('chart-patch', {
+        workingTree: newTree,
+        updatedAt: '2025-06-15T00:00:00.000Z',
+      });
 
       const retrieved = await db.getChart('chart-patch');
       expect(retrieved!.workingTree.name).toBe('Updated Root');


### PR DESCRIPTION
## Summary
- surface rollback recovery failures in full-replace restore errors so the toast can report when rollback also failed
- add ChartDB.getAllVersions() and use it to snapshot versions in one bulk read during full-replace restore
- add regression coverage for rollback error surfacing and bulk version reads

## Validation
- npm test -- tests/store/backup-manager.test.ts tests/store/chart-db.test.ts
- npm test
- npm run format
- npm run lint *(repo has pre-existing unrelated lint errors outside these changes)*