### PR TITLE
fix: validate bundle import flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Import wizard now handles `.arbol.json` chart bundles** — Exported charts can now be re-imported via the Import button. The wizard detects ChartBundle format, imports categories, level mappings, and saved versions. Previously it rejected these files with "Root node must have id, name, and title fields".
+- **Bundle import validation hardening** — Preview now validates bundle version trees, trims chart-name overrides, warns when malformed saved versions are skipped, and routes imported charts through the shared chart-switch flow.
 
 ## [3.13.1] — 2026-05-11
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1294,6 +1294,8 @@ const en: Record<string, string> = {
   'import_wizard.bundle_invalid_root':
     'Invalid chart bundle: working tree root must have id, name, and title',
   'import_wizard.bundle_info': 'Chart "{name}" with {count} saved version(s)',
+  'import_wizard.bundle_versions_skipped':
+    'Skipped {count} malformed saved version(s). Only valid versions will be imported.',
   'settings_modal.tab.presets': 'Presets',
   'settings_modal.tab.layout': 'Layout',
   'settings_modal.tab.typography': 'Typography',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1252,6 +1252,8 @@ const es: Record<string, string> = {
   'import_wizard.bundle_invalid_root':
     'Paquete de organigrama inválido: el nodo raíz debe tener id, nombre y cargo',
   'import_wizard.bundle_info': 'Organigrama "{name}" con {count} versión(es) guardada(s)',
+  'import_wizard.bundle_versions_skipped':
+    'Se omitieron {count} versión(es) guardada(s) malformada(s). Solo se importarán las versiones válidas.',
   'settings_modal.tab.presets': 'Preajustes',
   'settings_modal.tab.layout': 'Disposición',
   'settings_modal.tab.typography': 'Tipografía',

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,7 @@ import {
   renderPreviewStep,
   renderImportStep,
 } from './ui/import-wizard-steps';
+import { completeBundleImportActivation } from './ui/bundle-import-activation';
 import { importBundle } from './ui/bundle-import-handler';
 import { registerShortcuts } from './init/shortcuts-handler';
 import type { ChartRecord } from './types';
@@ -388,18 +389,16 @@ async function main(): Promise<void> {
             wizardState.chartName,
           );
           if (!chart) return;
-          await chartEditor.refresh();
-          store.replaceTree(chart.workingTree);
-          categoryStore.replaceAll(chart.categories);
-          levelStore.loadFromChart(chart);
-          chartNameHeader.setName(chart.name);
-          chartNameHeader.setDirty(false);
-          rerender();
-          renderer.getZoomManager()?.fitToContent();
-          announce(t('announce.chart_switched', { name: chart.name }));
-          importWizard.close();
-          wizardState = {};
-          showToast(t('footer.imported'), 'success');
+          await completeBundleImportActivation(chart, {
+            refreshChartEditor: () => chartEditor.refresh(),
+            handleChartSwitched,
+            fitToContent: () => renderer.getZoomManager()?.fitToContent(),
+            closeWizard: () => importWizard.close(),
+            resetWizardState: () => {
+              wizardState = {};
+            },
+            showImportToast: () => showToast(t('footer.imported'), 'success'),
+          });
           return;
         }
 

--- a/src/ui/bundle-import-activation.ts
+++ b/src/ui/bundle-import-activation.ts
@@ -1,0 +1,22 @@
+import type { ChartRecord } from '../types';
+
+export interface BundleImportActivationDeps {
+  refreshChartEditor: () => Promise<void>;
+  handleChartSwitched: (chart: ChartRecord) => void;
+  fitToContent: () => void;
+  closeWizard: () => void;
+  resetWizardState: () => void;
+  showImportToast: () => void;
+}
+
+export async function completeBundleImportActivation(
+  chart: ChartRecord,
+  deps: BundleImportActivationDeps,
+): Promise<void> {
+  await deps.refreshChartEditor();
+  deps.handleChartSwitched(chart);
+  deps.fitToContent();
+  deps.closeWizard();
+  deps.resetWizardState();
+  deps.showImportToast();
+}

--- a/src/ui/bundle-import-handler.ts
+++ b/src/ui/bundle-import-handler.ts
@@ -29,10 +29,12 @@ export async function importBundle(
   deps: BundleImportDeps,
   chartName?: string,
 ): Promise<ChartRecord | null> {
+  const trimmedChartName = chartName?.trim();
+
   // chartName override only applies to new chart imports
   const effectiveBundle =
-    destination === 'new' && chartName && chartName !== bundle.chart.name
-      ? { ...bundle, chart: { ...bundle.chart, name: chartName } }
+    destination === 'new' && trimmedChartName && trimmedChartName !== bundle.chart.name
+      ? { ...bundle, chart: { ...bundle.chart, name: trimmedChartName } }
       : bundle;
 
   if (destination === 'replace') {

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -272,25 +272,32 @@ function countNodes(node: OrgNode): number {
   return count;
 }
 
-function validateBundleVersions(versions: unknown): ChartBundleVersion[] {
+function validateBundleVersions(versions: unknown): {
+  versions: ChartBundleVersion[];
+  skippedCount: number;
+} {
   if (!Array.isArray(versions)) {
     console.warn('Skipping malformed bundle versions array during preview');
-    return [];
+    return { versions: [], skippedCount: 1 };
   }
 
   const validVersions: ChartBundleVersion[] = [];
+  let skippedCount = 0;
   for (const [index, version] of versions.entries()) {
     if (!version || typeof version !== 'object') {
+      skippedCount++;
       console.warn(`Skipping malformed bundle version at index ${index}: expected an object`);
       continue;
     }
 
     const candidate = version as Record<string, unknown>;
     if (typeof candidate.name !== 'string' || !candidate.name.trim()) {
+      skippedCount++;
       console.warn(`Skipping malformed bundle version at index ${index}: missing name`);
       continue;
     }
     if (typeof candidate.createdAt !== 'string' || !candidate.createdAt.trim()) {
+      skippedCount++;
       console.warn(`Skipping malformed bundle version at index ${index}: missing createdAt`);
       continue;
     }
@@ -303,13 +310,14 @@ function validateBundleVersions(versions: unknown): ChartBundleVersion[] {
         tree: candidate.tree,
       });
     } catch (error) {
+      skippedCount++;
       console.warn(
         `Skipping malformed bundle version at index ${index}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }
 
-  return validVersions;
+  return { versions: validVersions, skippedCount };
 }
 
 export function renderPreviewStep(
@@ -341,13 +349,19 @@ export function renderPreviewStep(
           throw new Error(t('import_wizard.bundle_invalid_root'));
         }
         validateTree(root);
-        state.bundle = { ...bundle, versions: validateBundleVersions(bundle.versions) };
+        const { versions, skippedCount } = validateBundleVersions(bundle.versions);
+        state.bundle = { ...bundle, versions };
+        state.warning =
+          skippedCount > 0
+            ? t('import_wizard.bundle_versions_skipped', { count: String(skippedCount) })
+            : undefined;
         state.tree = root;
         state.nodeCount = countNodes(root);
         state.destination = undefined;
         state.chartName = undefined;
       } else {
         state.bundle = undefined;
+        state.warning = undefined;
         state.destination = undefined;
         state.chartName = undefined;
         if (!parsed.id || !parsed.name || !parsed.title) {
@@ -358,6 +372,7 @@ export function renderPreviewStep(
       }
     } else {
       state.bundle = undefined;
+      state.warning = undefined;
       state.destination = undefined;
       state.chartName = undefined;
       const result = parseCsvToTree(state.rawText!, state.mapping);
@@ -372,6 +387,13 @@ export function renderPreviewStep(
       format: state.format!,
     });
     container.appendChild(success);
+
+    if (state.warning) {
+      const warning = document.createElement('p');
+      warning.className = 'wizard-warning';
+      warning.textContent = state.warning;
+      container.appendChild(warning);
+    }
 
     // Show bundle version info if applicable
     if (state.bundle) {
@@ -481,6 +503,7 @@ export function renderPreviewStep(
 
     onReady(true);
   } catch (e) {
+    state.warning = undefined;
     const errorMsg = document.createElement('p');
     errorMsg.className = 'wizard-error';
     errorMsg.textContent = t('import_wizard.preview_error', {

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -1,11 +1,13 @@
 import type {
   ChartBundle,
+  ChartBundleVersion,
   ColumnMapping,
   MappingPreset,
   OrgNode,
   TextNormalization,
 } from '../types';
 import { t } from '../i18n';
+import { validateTree } from '../store/org-store';
 import { showToast } from './toast';
 import { extractHeaders, parseCsvToTree } from '../utils/csv-parser';
 import { normalizeText } from '../utils/text-normalize';
@@ -270,6 +272,46 @@ function countNodes(node: OrgNode): number {
   return count;
 }
 
+function validateBundleVersions(versions: unknown): ChartBundleVersion[] {
+  if (!Array.isArray(versions)) {
+    console.warn('Skipping malformed bundle versions array during preview');
+    return [];
+  }
+
+  const validVersions: ChartBundleVersion[] = [];
+  for (const [index, version] of versions.entries()) {
+    if (!version || typeof version !== 'object') {
+      console.warn(`Skipping malformed bundle version at index ${index}: expected an object`);
+      continue;
+    }
+
+    const candidate = version as Record<string, unknown>;
+    if (typeof candidate.name !== 'string' || !candidate.name.trim()) {
+      console.warn(`Skipping malformed bundle version at index ${index}: missing name`);
+      continue;
+    }
+    if (typeof candidate.createdAt !== 'string' || !candidate.createdAt.trim()) {
+      console.warn(`Skipping malformed bundle version at index ${index}: missing createdAt`);
+      continue;
+    }
+
+    try {
+      validateTree(candidate.tree);
+      validVersions.push({
+        name: candidate.name,
+        createdAt: candidate.createdAt,
+        tree: candidate.tree,
+      });
+    } catch (error) {
+      console.warn(
+        `Skipping malformed bundle version at index ${index}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return validVersions;
+}
+
 export function renderPreviewStep(
   container: HTMLElement,
   state: WizardState,
@@ -298,7 +340,8 @@ export function renderPreviewStep(
         if (!root.id || !root.name || !root.title) {
           throw new Error(t('import_wizard.bundle_invalid_root'));
         }
-        state.bundle = bundle;
+        validateTree(root);
+        state.bundle = { ...bundle, versions: validateBundleVersions(bundle.versions) };
         state.tree = root;
         state.nodeCount = countNodes(root);
         state.destination = undefined;
@@ -549,7 +592,7 @@ export function renderImportStep(
   nameInput.placeholder = t('import_wizard.dest_name_placeholder');
   nameInput.value = state.chartName ?? '';
   nameInput.addEventListener('input', () => {
-    state.chartName = nameInput.value;
+    state.chartName = nameInput.value.trim();
   });
   nameField.appendChild(nameInput);
   container.appendChild(nameField);

--- a/tests/ui/bundle-import-activation.test.ts
+++ b/tests/ui/bundle-import-activation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ChartRecord } from '../../src/types';
+import { completeBundleImportActivation } from '../../src/ui/bundle-import-activation';
+
+function makeChart(): ChartRecord {
+  return {
+    id: 'chart-1',
+    name: 'Imported Chart',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    workingTree: { id: '1', name: 'Alice', title: 'CEO' },
+    categories: [],
+  };
+}
+
+describe('completeBundleImportActivation', () => {
+  it('routes imported charts through the shared chart switch handler', async () => {
+    const deps = {
+      refreshChartEditor: vi.fn().mockResolvedValue(undefined),
+      handleChartSwitched: vi.fn(),
+      fitToContent: vi.fn(),
+      closeWizard: vi.fn(),
+      resetWizardState: vi.fn(),
+      showImportToast: vi.fn(),
+    };
+
+    await completeBundleImportActivation(makeChart(), deps);
+
+    expect(deps.refreshChartEditor).toHaveBeenCalledOnce();
+    expect(deps.handleChartSwitched).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Imported Chart' }),
+    );
+    expect(deps.fitToContent).toHaveBeenCalledOnce();
+    expect(deps.closeWizard).toHaveBeenCalledOnce();
+    expect(deps.resetWizardState).toHaveBeenCalledOnce();
+    expect(deps.showImportToast).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/ui/bundle-import-handler.test.ts
+++ b/tests/ui/bundle-import-handler.test.ts
@@ -118,10 +118,10 @@ describe('importBundle', () => {
     expect(deps.showConfirmDialog).not.toHaveBeenCalled();
   });
 
-  it('overrides bundle chart name with user-provided chartName', async () => {
+  it('overrides bundle chart name with a trimmed user-provided chartName', async () => {
     const bundle = makeBundle();
     const deps = makeDeps();
-    await importBundle(bundle, 'new', deps, 'Custom Name');
+    await importBundle(bundle, 'new', deps, '  Custom Name  ');
     const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
     expect(passedBundle.chart.name).toBe('Custom Name');
     // Original bundle should not be mutated
@@ -132,6 +132,22 @@ describe('importBundle', () => {
     const bundle = makeBundle();
     const deps = makeDeps();
     await importBundle(bundle, 'new', deps);
+    const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
+    expect(passedBundle.chart.name).toBe('Test Chart');
+  });
+
+  it('ignores whitespace-only chartName overrides for new imports', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps();
+    await importBundle(bundle, 'new', deps, '   ');
+    const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
+    expect(passedBundle.chart.name).toBe('Test Chart');
+  });
+
+  it('ignores chartName overrides that only differ by surrounding whitespace', async () => {
+    const bundle = makeBundle();
+    const deps = makeDeps();
+    await importBundle(bundle, 'new', deps, '  Test Chart  ');
     const passedBundle = deps.importChartAsNew.mock.calls[0][0] as ChartBundle;
     expect(passedBundle.chart.name).toBe('Test Chart');
   });

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -437,11 +437,11 @@ describe('renderImportStep', () => {
     expect(state.destination).toBe('replace');
   });
 
-  it('stores chartName on input', () => {
+  it('stores trimmed chartName on input', () => {
     const state: WizardState = { nodeCount: 3, format: 'JSON', destination: 'new' };
     renderImportStep(container, state, vi.fn());
     const nameInput = container.querySelector('.wizard-field input') as HTMLInputElement;
-    nameInput.value = 'My Team Chart';
+    nameInput.value = '  My Team Chart  ';
     nameInput.dispatchEvent(new Event('input'));
     expect(state.chartName).toBe('My Team Chart');
   });
@@ -493,6 +493,7 @@ describe('renderPreviewStep — ChartBundle', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     document.body.removeChild(container);
   });
 
@@ -625,6 +626,34 @@ describe('renderPreviewStep — ChartBundle', () => {
     expect(success).not.toBeNull();
     expect(state.bundle).toBeDefined();
     expect(state.bundle!.versions).toHaveLength(0);
+  });
+
+  it('skips malformed bundle versions during preview and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const state: WizardState = {
+      format: 'JSON',
+      rawText: makeBundle({
+        versions: [
+          {
+            name: 'v1',
+            createdAt: '2025-01-01T00:00:00Z',
+            tree: { id: '1', name: 'Alice', title: 'CEO' },
+          },
+          {
+            name: 'Broken version',
+            createdAt: '2025-01-02T00:00:00Z',
+            tree: { name: 'Missing id', title: 'VP' },
+          },
+        ],
+      }),
+    };
+
+    renderPreviewStep(container, state, vi.fn());
+
+    expect(state.bundle).toBeDefined();
+    expect(state.bundle!.versions).toHaveLength(1);
+    expect(state.bundle!.versions[0].name).toBe('v1');
+    expect(warnSpy).toHaveBeenCalled();
   });
 
   it('clears stale bundle when switching to plain JSON', () => {

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -654,6 +654,9 @@ describe('renderPreviewStep — ChartBundle', () => {
     expect(state.bundle!.versions).toHaveLength(1);
     expect(state.bundle!.versions[0].name).toBe('v1');
     expect(warnSpy).toHaveBeenCalled();
+    const warning = container.querySelector('.wizard-warning');
+    expect(warning).not.toBeNull();
+    expect(warning!.textContent).toContain('Skipped 1 malformed saved version');
   });
 
   it('clears stale bundle when switching to plain JSON', () => {


### PR DESCRIPTION
## Summary
- validate bundle versions during preview and skip malformed entries with warnings
- trim chart-name overrides in the wizard and bundle import handler
- route bundle activation through the shared chart-switch path
- document the bundle import hardening in the changelog

## Verification
- npm test
- npm run lint (baseline repo issues remain; changed files lint clean via npx eslint src/main.ts src/ui/import-wizard-steps.ts src/ui/bundle-import-handler.ts src/ui/bundle-import-activation.ts src/i18n/en.ts src/i18n/es.ts tests/ui/import-wizard-steps.test.ts tests/ui/bundle-import-handler.test.ts tests/ui/bundle-import-activation.test.ts)

## Sentinel
- Report ID: sentinel-fix-bundle-import-validation-cc1b9de-20260514T201938-0700
- Reviewed SHA: cc1b9dec0842da02ccf7258a4cf4ba425755aeae
- Verdict: APPROVED