### PR TITLE
docs(readme): update import docs for ChartBundle and sync roadmap status

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ An interactive org chart editor for the browser — manage multiple org charts w
 - **Category & level mapping presets** — save reusable presets, copy from other charts, pick presets when creating new charts
 - **Chart name in header** — editable name with dirty-state indicator (●) and quick save button (💾)
 - **IndexedDB storage** — org data stored in IndexedDB for capacity across multiple charts and versions
-- **Import creates or replaces** — importing CSV/JSON asks whether to create a new chart or replace the current one
+- **Import creates or replaces** — importing CSV/JSON or re-importing `.arbol.json` ChartBundle exports asks whether to create a new chart or replace the current one
 - **Unsaved-changes warnings** — switching charts or restoring versions warns if the current tree has unsaved changes
 - **Accessible org chart** — full keyboard navigation (arrow keys, Enter, Space), ARIA tree semantics, screen reader announcements
 - **Mobile responsive** — collapsible sidebar on tablet/phone, touch-friendly 44px targets, works at 200% zoom
@@ -23,7 +23,7 @@ An interactive org chart editor for the browser — manage multiple org charts w
 - **First-time guidance** — help dialog with Getting Started guide for new users, contextual "no results" hints
 - **Loading indicators** — visual feedback for exports, imports, chart switching
 - Interactive hierarchical org chart visualization
-- Four sidebar tabs: People (add/edit), Import (files, paste, JSON editor, text normalization), Settings (presets, categories, fine-tuning), Charts (chart & version management)
+- Four sidebar tabs: People (add/edit), Import (files, paste, JSON editor, `.arbol.json` ChartBundle re-import, text normalization), Settings (presets, categories, fine-tuning), Charts (chart & version management)
 - Text normalization — normalize name/title casing (Title Case, UPPERCASE, lowercase) on import or for the existing org chart
 - Per-node color categories (Open Position, Offer Pending, Future Start + custom)
 - Color category legend on the chart (SVG overlay, included in PPTX export)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,7 @@ Arbol is an interactive org chart editor for the browser, built with TypeScript,
 - [x] Import wizard detects `.arbol.json` ChartBundle format
 - [x] Imports categories, level mappings, and saved versions from bundles
 - [x] Previously rejected these files with "Root node must have id, name, and title fields"
+- Note: This release shipped the core ChartBundle round-trip path; remaining Sentinel validation hardening follow-ups stay open in Known Issues (#54, #55, #56).
 
 ---
 
@@ -44,6 +45,7 @@ Arbol is an interactive org chart editor for the browser, built with TypeScript,
 - [x] Clear-all blocks on backup failure — warning dialog required (#15)
 - [x] Version tree validation — malformed versions skipped with warning (#16)
 - [x] Bundle import metadata validation — categories, levelMappings, levelDisplayMode sanitized (#17)
+- Note: These completed items are the shipped baseline safeguards; remaining Sentinel backup/import hardening follow-ups stay open in Known Issues (#25, #26, #54, #55, #56).
 
 ### Performance
 - [x] Layout engine — O(n²) `shiftSubtree` replaced with O(n) offset accumulation (#18)
@@ -785,7 +787,7 @@ Arbol is an interactive org chart editor for the browser, built with TypeScript,
 - Cross-parent boundary spacing required careful D3 separation override (fixed)
 - Imported settings can override defaults if not cleared from localStorage
 - HR system CSV exports with trailing metadata caused orphan reference errors (fixed in v1.1.0)
-- Open Sentinel findings: bundle import validation (#54, #55, #56), backup restore resilience (#25, #26) — see [GitHub Issues](https://github.com/pedrofuentes/arbol/issues)
+- Open Sentinel follow-ups: remaining bundle import validation hardening (#54, #55, #56) and backup restore resilience hardening (#25, #26). The completed sections above capture the fixes already shipped; these follow-up issues are still open. See [GitHub Issues](https://github.com/pedrofuentes/arbol/issues)
 
 ---
 


### PR DESCRIPTION
Closes #57, closes #63, closes #64

- Updated README import bullets to mention .arbol.json ChartBundle re-import
- Clarified roadmap status for partially-fixed backup/import findings

Sentinel
- Report ID: SEN-PR74-c6d1790-20260524T180037-0700
- Reviewed SHA: c6d179038f973dcc5b73c31e3212e9642659de0d
- Verdict: APPROVED