### PR TITLE
refactor(first-visit): use named section identifier instead of magic index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **First-visit help now opens Getting Started reliably** — onboarding now targets the named "Getting Started" help section instead of a fragile numeric index, and invalid `initialSection` values safely fall back to the first section (#41, #42)
+
 ## [3.13.3] — 2026-05-14
 
 ### Fixed

--- a/src/init/first-visit-helper.ts
+++ b/src/init/first-visit-helper.ts
@@ -1,4 +1,4 @@
-import { showHelpDialog } from '../ui/help-dialog';
+import { HELP_SECTION_IDS, showHelpDialog } from '../ui/help-dialog';
 import { type IStorage, browserStorage } from '../utils/storage';
 
 const WELCOME_KEY = 'arbol-welcome-seen';
@@ -10,7 +10,7 @@ export function showFirstVisitHelp(
   if (storage.getItem(WELCOME_KEY)) return false;
 
   showHelpDialog({
-    initialSection: 1,
+    initialSection: HELP_SECTION_IDS.gettingStarted,
     onLoadSample,
   });
   storage.setItem(WELCOME_KEY, 'true');

--- a/src/ui/help-dialog.ts
+++ b/src/ui/help-dialog.ts
@@ -22,6 +22,12 @@ interface ShortcutEntry {
   desc: string;
 }
 
+export const HELP_SECTION_IDS = {
+  gettingStarted: 'help.getting_started.title',
+} as const;
+
+export type HelpSectionId = (typeof HELP_SECTION_IDS)[keyof typeof HELP_SECTION_IDS];
+
 interface HelpSection {
   titleKey: string;
   type?: 'shortcuts-grid' | 'markdown';
@@ -30,6 +36,22 @@ interface HelpSection {
   markdown?: string;
   hasClearData?: boolean;
   hasSampleOrg?: boolean;
+}
+
+function resolveInitialSectionIndex(
+  sections: HelpSection[],
+  initialSection: number | HelpSectionId | undefined,
+): number {
+  if (typeof initialSection === 'string') {
+    const sectionIndex = sections.findIndex((section) => section.titleKey === initialSection);
+    return sectionIndex >= 0 ? sectionIndex : 0;
+  }
+
+  if (typeof initialSection === 'number') {
+    return initialSection >= 0 && initialSection < sections.length ? initialSection : 0;
+  }
+
+  return 0;
 }
 
 function getHelpSections(): HelpSection[] {
@@ -295,7 +317,7 @@ function getHelpSections(): HelpSection[] {
   if (appConfig.importInstructions?.trim()) {
     // Insert after "Getting Started" section
     const gettingStartedIdx = sections.findIndex(
-      (s) => s.titleKey === 'help.getting_started.title',
+      (section) => section.titleKey === HELP_SECTION_IDS.gettingStarted,
     );
     const insertAt = gettingStartedIdx >= 0 ? gettingStartedIdx + 1 : 0;
     sections.splice(insertAt, 0, {
@@ -425,7 +447,7 @@ function buildSampleOrgButton(onLoad: () => void, closeDialog: () => void): HTML
 export interface HelpDialogOptions {
   storage?: IStorage;
   onLoadSample?: () => void;
-  initialSection?: number;
+  initialSection?: number | HelpSectionId;
 }
 
 export function showHelpDialog(options: HelpDialogOptions = {}): void {
@@ -483,7 +505,7 @@ export function showHelpDialog(options: HelpDialogOptions = {}): void {
   content.style.scrollbarWidth = 'thin';
 
   const sections = getHelpSections();
-  const initialSection = options.initialSection ?? 0;
+  const initialSection = resolveInitialSectionIndex(sections, options.initialSection);
   const closeRef = { fn: () => {} };
   for (let i = 0; i < sections.length; i++) {
     const section = sections[i];

--- a/tests/init/first-visit-helper.test.ts
+++ b/tests/init/first-visit-helper.test.ts
@@ -56,13 +56,12 @@ describe('showFirstVisitHelp', () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it('opens Getting Started section (index 1) by default', () => {
+  it('opens the Getting Started section on first visit', () => {
     const storage = makeStorage();
     showFirstVisitHelp(vi.fn(), storage);
 
-    const sections = document.querySelectorAll('.help-section');
-    expect(sections[0].classList.contains('open')).toBe(false);
-    expect(sections[1].classList.contains('open')).toBe(true);
+    const openSectionHeader = document.querySelector('.help-section.open .help-section-header');
+    expect(openSectionHeader?.textContent).toContain('Getting Started');
   });
 
   it('passes onLoadSample to help dialog', () => {

--- a/tests/ui/help-dialog.test.ts
+++ b/tests/ui/help-dialog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { showHelpDialog } from '../../src/ui/help-dialog';
+import { HELP_SECTION_IDS, showHelpDialog } from '../../src/ui/help-dialog';
 
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -270,24 +270,25 @@ describe('showHelpDialog', () => {
 
   // ─── initialSection Tests ─────────────────────────────────────────
 
-  it('opens Getting Started section when initialSection is 1', () => {
-    showHelpDialog({ initialSection: 1 });
-    const sections = document.querySelectorAll('.help-section');
-    expect(sections[0].classList.contains('open')).toBe(false);
-    expect(sections[1].classList.contains('open')).toBe(true);
+  it('opens Getting Started section when initialSection uses a named section id', () => {
+    showHelpDialog({ initialSection: HELP_SECTION_IDS.gettingStarted });
+    const openSectionHeader = document.querySelector('.help-section.open .help-section-header');
+    expect(openSectionHeader?.textContent).toContain('Getting Started');
   });
 
-  it('sets aria-expanded correctly for initialSection', () => {
-    showHelpDialog({ initialSection: 1 });
+  it('sets aria-expanded correctly for a named initialSection', () => {
+    showHelpDialog({ initialSection: HELP_SECTION_IDS.gettingStarted });
     const headers = document.querySelectorAll('.help-section-header');
-    expect(headers[0].getAttribute('aria-expanded')).toBe('false');
-    expect(headers[1].getAttribute('aria-expanded')).toBe('true');
+    expect(headers[0].getAttribute('aria-expanded')).toBe('true');
+    expect(headers[1].getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('defaults to section 0 when initialSection is not provided', () => {
-    showHelpDialog();
-    const sections = document.querySelectorAll('.help-section');
-    expect(sections[0].classList.contains('open')).toBe(true);
-    expect(sections[1].classList.contains('open')).toBe(false);
-  });
+  it.each([-1, 999, undefined])(
+    'gracefully defaults to the first section when initialSection is %s',
+    (initialSection) => {
+      showHelpDialog({ initialSection });
+      const openSectionHeader = document.querySelector('.help-section.open .help-section-header');
+      expect(openSectionHeader?.textContent).toContain('Getting Started');
+    },
+  );
 });


### PR DESCRIPTION
Closes #41, closes #42

### Changes
- Replaced magic initialSection: 1 with named section lookup
- Added edge-case handling for invalid initialSection values
- Added tests for named section identification and edge cases

### Verification
- 
pm test Γ£à (2924 passed)
- 
pm run lint ΓÜá∩╕Å blocked by pre-existing repo-wide lint failures in untouched files; changed files pass 
px eslint src/init/first-visit-helper.ts src/ui/help-dialog.ts tests/init/first-visit-helper.test.ts tests/ui/help-dialog.test.ts

### TDD commits
1. 	est(first-visit): failing tests for named section + edge cases
2. efactor(first-visit): implementation using named identifier

### Sentinel
- Report ID: sentinel-pr75-c45b465
- Reviewed SHA: c45b465a45e44601f5f53322c658b5d3f1a81787
- Verdict: APPROVED
