### PR TITLE
docs(decisions): fix ADR ordering and improve backup-manager comments

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -22,6 +22,14 @@
 
 <!-- Add new decisions below this line, most recent first -->
 
+### ADR-007: Atomic backup restore with rollback
+**Date**: 2026-05-05
+**Status**: Accepted
+**Context**: `restoreFullReplace()` deleted all existing charts before writing backup data. A failure mid-write left the app in an empty/partial state with no recovery path.
+**Decision**: Validate all backup data upfront, snapshot existing data, then delete+write. If writing fails, roll back by re-inserting the snapshot.
+**Alternatives considered**: (1) Two-phase IndexedDB transaction — not feasible with the current `ChartDB` abstraction. (2) Write-then-swap with temporary stores — adds complexity for marginal benefit.
+**Consequences**: Slightly higher memory usage during restore (holds both old and new data). Eliminates guaranteed data loss by giving failed restores a recovery path instead of certain destruction. Rollback is still best-effort (if rollback itself fails, data may still be lost — but this is the same as the original situation and strictly better than guaranteed loss).
+
 ### ADR-005: agents-template v0.3.0 adoption
 **Date**: 2026-05-05
 **Status**: Accepted
@@ -61,11 +69,3 @@
 **Decision**: Vanilla TypeScript for all non-SVG UI (sidebar, dialogs, menus). D3 owns the SVG exclusively.
 **Alternatives considered**: React with refs for D3 integration, Svelte.
 **Consequences**: No virtual DOM overhead. Full control over DOM manipulation. Requires manual DOM helpers for UI components (`createElement`, `appendChild`, `textContent`). Every UI component is a class or function that returns/manipulates DOM elements directly.
-
-### ADR-007: Atomic backup restore with rollback
-**Date**: 2026-05-05
-**Status**: Accepted
-**Context**: `restoreFullReplace()` deleted all existing charts before writing backup data. A failure mid-write left the app in an empty/partial state with no recovery path.
-**Decision**: Validate all backup data upfront, snapshot existing data, then delete+write. If writing fails, roll back by re-inserting the snapshot.
-**Alternatives considered**: (1) Two-phase IndexedDB transaction — not feasible with the current `ChartDB` abstraction. (2) Write-then-swap with temporary stores — adds complexity for marginal benefit.
-**Consequences**: Slightly higher memory usage during restore (holds both old and new data). Guarantees users never lose data due to a restore failure. Rollback is best-effort (if rollback itself fails, data may still be lost — but this is the same as the original situation and strictly better than guaranteed loss).

--- a/src/store/backup-manager.ts
+++ b/src/store/backup-manager.ts
@@ -168,7 +168,7 @@ export async function restoreFullReplace(
   backup: ArbolBackup,
   storage: IStorage = browserStorage,
 ): Promise<void> {
-  // Stage 1: Validate all backup data before any destructive operations
+  // Stage 1 validates first so a malformed backup cannot erase working data before we know what is safe to import.
   const validChartIds = new Set<string>();
   const validCharts: ChartRecord[] = [];
   for (const chart of backup.data.charts) {
@@ -181,7 +181,7 @@ export async function restoreFullReplace(
     }
   }
 
-  // Filter versions to only those belonging to valid charts
+  // Versions for rejected charts are excluded to preserve referential integrity in the recovered dataset.
   const validVersions: VersionRecord[] = [];
   for (const version of backup.data.versions) {
     if (!validChartIds.has(version.chartId)) continue;
@@ -195,7 +195,7 @@ export async function restoreFullReplace(
     }
   }
 
-  // Stage 2: Snapshot existing data for rollback
+  // Stage 2 snapshots the current state because `ChartDB` cannot replace everything in one atomic transaction.
   const existingCharts = await db.getAllCharts();
   const existingVersions = await db.getAllVersions();
   const existingLSValues: Record<string, string | null> = {};
@@ -203,7 +203,7 @@ export async function restoreFullReplace(
     existingLSValues[key] = storage.getItem(key);
   }
 
-  // Stage 3: Clear existing data, write backup, restore localStorage — all rollback-protected
+  // Stage 3 delays destructive writes until rollback data exists, so a partial restore can be unwound instead of becoming permanent.
   const writtenChartIds: string[] = [];
   const writtenVersionIds: string[] = [];
   try {
@@ -227,7 +227,7 @@ export async function restoreFullReplace(
   } catch (error) {
     const rollbackErrors: unknown[] = [];
 
-    // Best-effort rollback: attempt all recovery steps, never abort mid-recovery
+    // Rollback stays best-effort so one failed recovery step does not prevent the rest of the user's pre-restore data from coming back.
     for (const id of writtenVersionIds) {
       try {
         await db.deleteVersion(id);


### PR DESCRIPTION
Closes #28, closes #29

- Moved ADR-007 to newest-first position in DECISIONS.md
- Rephrased backup-manager stage comments for rationale instead of control flow

Sentinel
- Report ID: SEN-20260524-180415-808a4f5
- Reviewed SHA: 808a4f5a95db0d21c544f250b8a25ddbc5218657
- Verdict: APPROVED