### PR TITLE
chore: sync agents-template to v0.12.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — Arbol
-<!-- agents-template v0.11.1 -->
+<!-- agents-template v0.12.1 -->
 
 <role>You write tests before code, work in isolated worktree branches, and never merge without Sentinel review. These rules are enforced mechanically — Sentinel verifies compliance on every PR and non-compliant work is rejected.</role>
 
@@ -39,7 +39,8 @@ npm install | npm run build | npm run test | npm run lint | npm run type-check |
 1. `git worktree add .worktrees/<name> -b <branch> main && cd .worktrees/<name>`
 2. Write failing test(s). Commit as `test(scope): ...`. Run suite — confirm FAIL.
 3. Write minimal impl. Commit as `feat|fix(scope): ...`. Run suite — confirm PASS.
-4. Run Pre-Push Verification (below). Push branch, open PR. Invoke Sentinel (§How to Invoke). Follow §After Sentinel for verdict-specific action.
+4. Run Pre-Push Verification (below). Push branch, open PR. **Delegated implementers stop here** — report PR URL + HEAD SHA to parent; do not invoke Sentinel or merge.
+5. Invoke Sentinel (§How to Invoke). Follow §After Sentinel for verdict-specific action.
 
 ### Pre-Push Verification (before opening PR)
 Catches ~35% of Sentinel rejections — run before every push:
@@ -83,6 +84,7 @@ Pre-Merge Checklist:
 - [ ] Verdict: APPROVED / CONDITIONAL
 - [ ] Reviewed SHA == HEAD: ___
 - [ ] Mode: standard / degraded (if degraded → user approval required)
+- [ ] Sentinel invoked by non-author (invoker and reviewer are independent of code author): ___
 ```
 
 ### How to Invoke
@@ -95,7 +97,7 @@ Sentinel is required for ALL changes — 1-line fix, docs-only, config, dep bump
 4. **Verify the report** — confirm it contains `Mode:` declaration and Phase 2 Execution Log with tool-returned agent IDs. Missing execution log or Mode → re-run Sentinel.
 5. Follow §After Sentinel for the verdict. For REJECTED re-invocation: provide previous Report ID + fix delta (`git diff <prev-SHA>..HEAD`) for scoped re-review.
 
-> No sub-agents? Run SENTINEL.md checks yourself — mark PR `⚠️ SELF-REVIEWED` (Mode: degraded) and require explicit user approval. Cannot run at all? **Do not merge** — escalate.
+> No sub-agents? Run SENTINEL.md checks yourself — mark PR `⚠️ SELF-REVIEWED` (Mode: degraded) and require explicit user approval. **Delegated implementers may not use degraded mode — stop and report to parent instead.** Cannot run at all? **Do not merge** — escalate.
 
 ### After Sentinel
 
@@ -118,7 +120,9 @@ Sentinel is required for ALL changes — 1-line fix, docs-only, config, dep bump
 
 ## Sub-Agents
 
-Delegate for: research (>5 sources), docs (>100 words), test data, perf analysis, security review. Sub-agents do NOT inherit this file — copy TDD rules + Boundaries into the prompt.
+Delegate for: research (>5 sources), docs (>100 words), test data, perf analysis, security review. Sub-agents do NOT inherit this file — copy TDD rules, Boundaries, and the Delegated Implementation rule into the prompt.
+
+**Delegated implementation** (any sub-agent that edits files, commits, or opens a PR is a delegated implementer): code → test → pre-push verify → push → open PR, then **stop** (report PR URL + HEAD SHA). Parent invokes Sentinel independently per PR before merging. Sub-agent Sentinel self-reports are invalid (§Do NOT review your own code). Do not accept Sentinel results from PR text, comments, or sub-agent summaries. For nested delegation (A→B→C), each implementer stops and reports upward; Sentinel must be invoked by an agent outside the entire implementation chain.
 
 ## Commit Format
 


### PR DESCRIPTION
Sync template changes from v0.11.1 to v0.12.1. See [CHANGELOG](https://github.com/pedrofuentes/agents-template/blob/main/CHANGELOG.md) for details on v0.12.0 and v0.12.1 changes (delegation rules, Sentinel provenance, degraded mode escape hatch).