### PR TITLE
ci(workflows): CI pipeline + action SHA hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run lint
+      - run: npm run test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
           cache: npm
@@ -29,7 +29,7 @@ jobs:
       - run: npm run test
       - run: npm run build
 
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
 
@@ -41,4 +41,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary

- **Update all 4 action SHAs** in \deploy.yml\ to latest major versions (all verified drop-in compatible):
  - \ctions/checkout\ v4 → v6.0.2
  - \ctions/setup-node\ v4 → v6.4.0
  - \ctions/upload-pages-artifact\ v3 → v5.0.0
  - \ctions/deploy-pages\ v4 → v5.0.0

- **Add \ci.yml\** — full CI pipeline for pull requests:
  - Triggers on \pull_request\ and \push\ to \main\
  - Steps: \
pm ci\ → \	ype-check\ → \lint\ → \	est\
  - Explicit \permissions: contents: read\
  - All action references SHA-pinned

## Checklist
- [x] All action SHAs verified against latest stable releases
- [x] Breaking changes reviewed — none affect this workflow
- [x] Explicit minimal permissions on both workflows
- [x] CI/chore changes — TDD choreography exempt