### PR TITLE
ci(workflows): add npm audit step to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm audit --audit-level=high
       - run: npm run type-check
       - run: npm run lint
       - run: npm run test


### PR DESCRIPTION
Add \
pm audit --audit-level=high\ after \
pm ci\ in the CI workflow to catch known vulnerabilities early in the pipeline.

Closes #91

**Changes:**
- \.github/workflows/ci.yml\: new audit step between \
pm ci\ and \
pm run type-check\

This is a CI-only change — no code or test changes.