### PR TITLE
docs: update contributor docs for CI pipeline, Release Please, and uuid override

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -22,6 +22,14 @@
 
 <!-- Add new decisions below this line, most recent first -->
 
+### ADR-008: uuid@14 override is safe for exceljs@4.4.0
+**Date**: 2026-05-25
+**Status**: Accepted
+**Context**: PR #89 added `"overrides": { "uuid": ">=11.1.1" }` to fix CVE-2024-22025 in transitive uuid@8 (via exceljs). Need to verify exceljs still works with uuid@14.
+**Decision**: Override is safe. exceljs uses uuid **only** in `lib/xlsx/xform/sheet/cf-ext/cf-rule-ext-xform.js` for generating conditional formatting rule IDs. The call is `v4()` with no arguments — the stable public API that is backward-compatible across all uuid major versions. The CVE's vulnerable code path (passing a `buf` argument to v3/v5/v6) is never triggered by exceljs.
+**Alternatives considered**: (1) Pin uuid to ^8.3.2 (patched within v8) — no such patch exists; v8 is unmaintained. (2) Remove exceljs entirely — it's used for .xlsx import (`import-editor.ts`). (3) Fork exceljs to remove uuid dependency — excessive maintenance burden.
+**Consequences**: Users can import .xlsx files with conditional formatting without issues. The override resolves the CVE audit finding while maintaining full exceljs compatibility.
+
 ### ADR-007: Atomic backup restore with rollback
 **Date**: 2026-05-05
 **Status**: Accepted

--- a/docs/DEVELOPMENT-WORKFLOW.md
+++ b/docs/DEVELOPMENT-WORKFLOW.md
@@ -71,23 +71,27 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `ci`, `style`, `perf`
 ## Pull Request Process
 
 ### Before Opening a PR
-1. All 2,922+ tests pass: `npm run test`
+1. Type checking passes: `npm run type-check`
 2. Linting passes: `npm run lint`
-3. Build succeeds: `npm run build`
-4. Commit messages follow the format
-5. PR represents a single logical unit
+3. All 2,922+ tests pass: `npm run test`
+4. Build succeeds: `npm run build`
+5. Commit messages follow the format
+6. PR represents a single logical unit
 
-### Pre-Merge Version Bump (Final Commit)
+> **CI runs automatically** on every PR: `npm ci` → `npm audit --audit-level=high` → `type-check` → `lint` → `test`. All steps must pass before merge.
 
-Before requesting merge, the final commit must include:
+### Versioning (Release Please)
 
-1. **Bump `version` in `package.json`** — patch (bug fix), minor (new feature), major (breaking change)
-2. **Update `CHANGELOG.md`** — new `## [x.y.z]` section with Added/Changed/Fixed/Removed
-3. **Update `docs/roadmap.md`** — mark completed items `[x]`
-4. **Update other docs if affected** — `README.md`, `docs/contributing.md`, `AGENTS.md`
-5. **Commit:** `chore: bump version to x.y.z`
+Versioning is **automated** via [Release Please](https://github.com/googleapis/release-please). Do NOT manually bump `package.json` or edit `CHANGELOG.md` — Release Please handles both based on conventional commit messages.
+
+**How it works:**
+1. Merge PRs to `main` with conventional commits (`feat:`, `fix:`, `perf:`, etc.)
+2. Release Please opens/updates a release PR that bumps the version and generates changelog entries
+3. When the release PR is merged, a GitHub Release is created automatically
 
 The version in `package.json` is the single source of truth — injected into the app at build time and displayed in the footer.
+
+> **Note:** AGENTS.md still references manual version bumps in the 🚫 NEVER section (line 161). This needs a manual update to align with Release Please — see issue tracking.
 
 ### Sentinel Review
 → See [`docs/SENTINEL.md`](./SENTINEL.md) for the full process and invocation methods.

--- a/docs/TESTING-STRATEGY.md
+++ b/docs/TESTING-STRATEGY.md
@@ -140,7 +140,9 @@ describe('ModuleName', () => {
 
 ## CI Integration
 
-- Tests run automatically on every PR via GitHub Actions
+- CI runs automatically on every PR via GitHub Actions (`ci.yml`)
+- Pipeline: `npm ci` → `npm audit --audit-level=high` → `type-check` → `lint` → `test`
+- All steps must pass before merge (enforced by branch protection)
 - All tests must pass before Sentinel review begins
 - Flaky tests must be fixed immediately, not skipped
 - Current test count: 2,922 tests across 121 files

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,15 +25,19 @@ npm run test    # verify the full test suite passes
 
 3. **Implement the feature.** Follow the [coding standards](../AGENTS.md#coding-standards).
 
-4. **Run the full test suite:**
+4. **Run the full verification suite:**
    ```bash
-   npm run test
+   npm run type-check   # TypeScript type checking
+   npm run lint         # ESLint
+   npm run test         # All tests (2,922+ across 121 files)
    ```
 
-5. **Build for production** to catch TypeScript errors:
+5. **Build for production:**
    ```bash
    npm run build
    ```
+
+   > CI runs all of these automatically on every PR: type-check → lint → test.
 
 6. **Commit** with conventional message format:
    ```
@@ -88,7 +92,7 @@ Understanding these concepts is essential for working on the renderer:
 
 ## Testing Guidelines
 
-- Always run `npm run test` before committing
+- Always run `npm run type-check && npm run lint && npm run test` before committing
 - Spacing changes must include regression tests (see `chart-renderer.test.ts`)
 - Store modules should test persistence, serialization, and edge cases
 - UI modules with business logic need unit tests; purely presentational DOM builders are optional
@@ -119,14 +123,14 @@ Key naming convention: `area.component.specific` — e.g., `'menu.edit'`, `'dial
 
 ## Versioning
 
-Arbol follows [Semantic Versioning](https://semver.org/). Before every merge to `main`:
+Arbol follows [Semantic Versioning](https://semver.org/). Versioning is **automated** via [Release Please](https://github.com/googleapis/release-please) — do NOT manually bump `package.json` or edit `CHANGELOG.md`.
 
-1. **Bump the version** in `package.json` (`patch` for fixes, `minor` for features, `major` for breaking changes)
-2. **Update `CHANGELOG.md`** with what changed
-3. **Update `docs/roadmap.md`** to mark completed items
-4. **Update any other affected docs** (README, contributing, AGENTS.md)
+**How it works:**
+1. Use [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `perf:`, etc.)
+2. Release Please automatically opens a release PR that bumps the version and generates changelog entries
+3. Merging the release PR creates a GitHub Release
 
-The version in `package.json` is the single source of truth — it's injected into the app at build time and displayed in the footer. See [AGENTS.md — Version & Docs Update](../AGENTS.md#4-version--docs-update-pre-merge) for the full process.
+The version in `package.json` is the single source of truth — it's injected into the app at build time and displayed in the footer.
 
 ## Need Help?
 


### PR DESCRIPTION
Update contributor-facing documentation to reflect the CI pipeline, Release Please versioning, and uuid@14 override safety.

**Changes:**
- \docs/DEVELOPMENT-WORKFLOW.md\: document full CI pipeline steps in 'Before Opening a PR'; replace manual version bump instructions with Release Please workflow
- \docs/contributing.md\: add type-check + lint to verification steps; replace manual versioning with Release Please; update testing guidelines
- \docs/TESTING-STRATEGY.md\: document full CI pipeline in CI Integration section
- \DECISIONS.md\: add ADR-008 documenting uuid@14 override safety for exceljs

> **Note:** AGENTS.md line 161 still references manual version bumps in the 🚫 NEVER section. This needs a manual update to align with Release Please (HUMAN REQUIRED per AGENTS.md rules).

Closes #92, #93, #94