### PR TITLE
fix(ci): fix CI pipeline failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4666,9 +4666,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/tests/export/pptx-exporter.test.ts
+++ b/tests/export/pptx-exporter.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { ShapeProps, SHAPE_NAME, TextProps, TextPropsOptions } from 'pptxgenjs';
 import type {
   LayoutResult,
   LayoutNode,
@@ -8,16 +7,59 @@ import type {
 } from '../../src/renderer/layout-engine';
 import type { ColorCategory } from '../../src/types';
 
+// Local type definitions for pptxgenjs mock call assertions.
+// pptxgenjs v4 exports types only via namespace (PptxGenJS.ShapeProps etc.),
+// and all properties are optional. These local definitions make commonly-asserted
+// properties required so test assertions compile under strict null checks.
+interface ShapeFill {
+  color: string;
+  transparency?: number;
+}
+interface ShapeLine {
+  color: string;
+  width: number;
+  dashType?: string;
+}
+interface ShapeProps {
+  fill: ShapeFill;
+  line: ShapeLine;
+  w: number;
+  h: number;
+  x: number;
+  y: number;
+  rectRadius?: number;
+}
+type SHAPE_NAME = string;
+interface TextPropsOptions {
+  fill?: ShapeFill;
+  line?: ShapeLine;
+  color?: string;
+  bold?: boolean;
+  align?: string;
+  valign?: string;
+  fontFace?: string;
+  fontSize?: number;
+  wrap?: boolean;
+  x?: number;
+  y?: number;
+  w?: number;
+  h?: number;
+}
+interface TextProps {
+  text?: string;
+  options?: TextPropsOptions;
+}
+
 // Mock pptxgenjs before importing exporter
 const mockWriteFile = vi.fn().mockResolvedValue(undefined);
 const mockAddText = vi.fn().mockReturnThis();
 const mockAddShape = vi.fn().mockReturnThis();
 const mockAddSlide = vi.fn();
 
-type TextCall = [string | TextProps[], TextPropsOptions?];
-type TextArrayCall = [TextProps[], TextPropsOptions?];
-type StringTextCall = [string, TextPropsOptions?];
-type ShapeCall = [SHAPE_NAME, ShapeProps?];
+type TextCall = [string | TextProps[], TextPropsOptions];
+type TextArrayCall = [TextProps[], TextPropsOptions];
+type StringTextCall = [string, TextPropsOptions];
+type ShapeCall = [SHAPE_NAME, ShapeProps];
 type MockSlide = { addText: typeof mockAddText; addShape: typeof mockAddShape };
 type SlideCall = [MockSlide];
 

--- a/tests/store/chart-store.test.ts
+++ b/tests/store/chart-store.test.ts
@@ -6,6 +6,7 @@ import type {
   OrgNode,
   ColorCategory,
   ChartBundle,
+  ChartRecord,
   LevelMapping,
   LevelDisplayMode,
 } from '../../src/types';


### PR DESCRIPTION
## Summary

Fixes all three failing CI workflows on \main\:

### 1. npm audit vulnerability (CI workflow)
- \	mp <0.2.6\ had a high-severity path traversal vulnerability (GHSA-ph9p-34f9-6g65)
- Fixed via \
pm audit fix\ — 0 vulnerabilities now

### 2. TypeScript type errors (Deploy workflow)
- \	ests/export/pptx-exporter.test.ts\: pptxgenjs v4 exports types via namespace (\xport as namespace PptxGenJS\), not as named exports. Replaced broken \import type { ShapeProps, ... }\ with local test-specific type definitions that also make commonly-asserted properties required (avoiding 100+ TS2532 strict null check errors).
- \	ests/store/chart-store.test.ts\: Added missing \ChartRecord\ import.

### 3. Release Please permissions (**manual fix required**)
- Error: \GitHub Actions is not permitted to create or approve pull requests\
- **Action needed**: Enable *Allow GitHub Actions to create and approve pull requests* in **Settings → Actions → General → Workflow permissions**
- This cannot be fixed via code — it's a repo settings change.

## Verification
- \
px tsc --noEmit\ ✅
- \
pm run test\ ✅ (2931 tests, 121 files)
- \
pm run lint\ ✅
- \
pm audit --audit-level=high\ ✅ (0 vulnerabilities)