### PR TITLE
chore(deps): upgrade typescript to 6.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.4",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vite": "^8.0.16",
         "vitest": "^4.1.9"
@@ -4524,9 +4524,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.9"


### PR DESCRIPTION
## What

Bump `typescript` `^5.9.3` -> `^6.0.3` (the major). Final increment of the dependency-upgrade series (after vite 8 in #104 and the tooling refresh in #106).

## Result

The codebase compiles cleanly under TypeScript 6 — **zero new type errors**, `tsconfig` unchanged. The lockfile delta is just the typescript version (TS has no transitive deps).

## Compatibility

- `typescript-eslint@8.61.0` supports TS 6 (peer `>=4.8.4 <6.1.0`).
- TS 6.0.3 is the GA `latest` release.

## Verification

- `npm run type-check` -> **0 errors**
- `npm run lint` -> 0 warnings
- `npm run build` -> success
- `npm run test` -> **2931 passed** (121 files)
- `npm audit --audit-level=high` -> 0 vulnerabilities