### PR TITLE
docs: update stale TS/Vite versions in AGENTS.md (closes #105)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 **Arbol** — An interactive org chart editor running entirely in the browser.
 
-- **Tech stack**: TypeScript, D3.js (tree layout + SVG), Vite (bundler), pptxgenjs (PowerPoint export) — versions: TS 5.9, D3 7.9, Vite 7.3
+- **Tech stack**: TypeScript, D3.js (tree layout + SVG), Vite (bundler), pptxgenjs (PowerPoint export) — versions: TS 6.0, D3 7.9, Vite 8.0
 - **Package manager**: npm | **Module system**: ES modules
 
 ## Commands


### PR DESCRIPTION
## What

Updates the stale version numbers on `AGENTS.md:18` (Project Overview tech stack):

- `TS 5.9` → `TS 6.0` (after #107)
- `Vite 7.3` → `Vite 8.0` (after #104)
- `D3 7.9` unchanged

Closes #105. The issue named only Vite; the TS version on the same line was also stale after the TypeScript 6 upgrade, so both are corrected.

## HUMAN-REQUIRED authorization

Editing `AGENTS.md` is HUMAN REQUIRED per the repo rules. Authorized by @pedrofuentes in this session: they requested *"review, describe #105 and ask for my approval"* and then approved the plan, which stated *"Approving this plan = your HUMAN-REQUIRED authorization to edit AGENTS.md."*

## Verification

- Docs-only change (single line in `AGENTS.md`; no source/test/build-config files touched).
- Sanity: `npm ci` → 0 vulnerabilities; `npm run lint` → 0 warnings; `npm run test` → **2931 passed**.
