### PR TITLE
chore(sentinel): sync agents-template to v0.23.1 (BACKLOG-HYGIENE §5 note)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # AGENTS.md — Arbol
-<!-- agents-template v0.23.0 -->
+<!-- agents-template v0.23.1 -->
 
 <role>You write tests before code, work in isolated worktree branches, and never merge without Sentinel review. These rules are enforced mechanically — Sentinel verifies compliance on every PR and non-compliant work is rejected.</role>
 

--- a/docs/sentinel/BACKLOG-HYGIENE.md
+++ b/docs/sentinel/BACKLOG-HYGIENE.md
@@ -72,13 +72,15 @@ The cheapest backlog item is the one never filed — keep the gate's existing le
 ## 5. Optional example Action (copy in only if you want scheduled flagging)
 A deterministic, **flag-only** first pass: it labels `sentinel:candidate-stale` when an anchored file is gone
 at HEAD. **It never closes and never adjudicates `sentinel:security`** — deeper re-validation (positive
-evidence, cross-file migration) is left to the human/agent §3 sweep. Pin the action to a full SHA.
+evidence, cross-file migration) is left to the human/agent §3 sweep. Pin the action to a full SHA. **When you
+copy it in, format the file to your repo's conventions (Prettier/ESLint/etc.) so your CI's lint/format check
+passes — keep the pinned action SHA and the logic intact.**
 
 ```yaml
 # .github/workflows/sentinel-backlog-hygiene.yml   (OPTIONAL — adopter opt-in)
 name: Sentinel Backlog Hygiene
 on:
-  schedule: [{ cron: '0 6 * * 1' }]   # weekly, Mondays 06:00 UTC
+  schedule: [{ cron: '0 6 * * 1' }] # weekly, Mondays 06:00 UTC
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
## Sync agents-template → v0.23.1 (BACKLOG-HYGIENE §5 formatting note)

Vendored-copy sync to [agents-template v0.23.1](https://github.com/pedrofuentes/agents-template/releases/tag/v0.23.1) — a docs/rollout-ergonomics release (ruleset stays **v1**).

### Changed
- **`docs/sentinel/BACKLOG-HYGIENE.md` §5** — the opt-in example workflow now carries a copy-in note to format it to this repo's conventions (Prettier/ESLint/etc.) so CI's lint/format check passes; the pinned action SHA + logic are unchanged. Example comment spacing tidied.
- **`AGENTS.md`** — marker bumped to v0.23.1.

No SENTINEL/dimension/rubric change; no new workflow, labels, or backfill. The already-installed backlog-hygiene workflow is unaffected.
