### PR TITLE
fix(editor): sync working-tree sidebar counts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,6 +178,7 @@ All mutating methods call `snapshot()` (saves undo state) then `emit()` (notifie
 | `deleteVersion()`   | `(versionId): Promise<void>`                                                   |
 | `restoreVersion()`  | `(versionId): Promise<void>` — replaces working tree                           |
 | `onChange()`        | `(listener): () => void`                                                       |
+| `onWorkingTreeSaved()` | `(listener): () => void` — lightweight post-persist people-count updates    |
 
 ### LevelStore (`src/store/level-store.ts`)
 

--- a/src/editor/chart-editor.ts
+++ b/src/editor/chart-editor.ts
@@ -73,6 +73,7 @@ export class ChartEditor {
   private latestPeopleCounts = new Map<string, number>();
   private pendingPeopleCounts = new Map<string, number>();
   private versionCounts = new Map<string, number>();
+  private chartNames = new Map<string, string>();
 
   constructor(options: ChartEditorOptions) {
     this.container = options.container;
@@ -232,6 +233,7 @@ export class ChartEditor {
 
     const charts = await this.chartStore.getCharts();
     const activeId = this.chartStore.getActiveChartId();
+    this.chartNames = new Map(charts.map((chart) => [chart.id, chart.name]));
 
     const filtered = this.chartSearchTerm
       ? charts.filter((c) => c.name.toLowerCase().includes(this.chartSearchTerm))
@@ -385,6 +387,7 @@ export class ChartEditor {
     ).find((item) => item.dataset.chartId === chartId);
     const metaEl = chartItem?.querySelector<HTMLElement>('.chart-item-meta');
     if (!metaEl) {
+      if (this.isChartFilteredOut(chartId)) return;
       console.warn(`Chart row not found for working-tree save: ${chartId}`);
       return;
     }
@@ -395,6 +398,13 @@ export class ChartEditor {
       return;
     }
     metaEl.textContent = this.formatChartMeta(peopleCount, versionCount);
+  }
+
+  private isChartFilteredOut(chartId: string): boolean {
+    const chartName = this.chartNames.get(chartId);
+    return Boolean(
+      this.chartSearchTerm && chartName && !chartName.toLowerCase().includes(this.chartSearchTerm),
+    );
   }
 
   // ── Render version list ────────────────────────────────

--- a/src/editor/chart-editor.ts
+++ b/src/editor/chart-editor.ts
@@ -70,6 +70,9 @@ export class ChartEditor {
   private errorTimers: ReturnType<typeof setTimeout>[] = [];
   private refreshInProgress = false;
   private refreshQueued = false;
+  private latestPeopleCounts = new Map<string, number>();
+  private pendingPeopleCounts = new Map<string, number>();
+  private versionCounts = new Map<string, number>();
 
   constructor(options: ChartEditorOptions) {
     this.container = options.container;
@@ -101,6 +104,7 @@ export class ChartEditor {
       await Promise.all([this.renderChartList(), this.renderVersionList()]);
     } finally {
       this.refreshInProgress = false;
+      this.applyPendingChartMetaUpdates();
       if (this.refreshQueued) {
         this.refreshQueued = false;
         await this.refresh();
@@ -243,16 +247,16 @@ export class ChartEditor {
     }
 
     // Pre-fetch version counts
-    const versionCounts = new Map<string, number>();
+    this.versionCounts.clear();
     for (const chart of filtered) {
       const versions = await this.chartStore.getVersions(chart.id);
-      versionCounts.set(chart.id, versions.length);
+      this.versionCounts.set(chart.id, versions.length);
     }
 
     for (const chart of filtered) {
       const isActive = chart.id === activeId;
       this.chartListEl.appendChild(
-        this.createChartItem(chart, isActive, versionCounts.get(chart.id) ?? 0),
+        this.createChartItem(chart, isActive, this.versionCounts.get(chart.id) ?? 0),
       );
     }
   }
@@ -306,8 +310,8 @@ export class ChartEditor {
 
     const metaEl = document.createElement('div');
     metaEl.className = 'chart-item-meta';
-    const peopleCount = flattenTree(chart.workingTree).length;
-    metaEl.dataset.versionCount = String(versionCount);
+    const peopleCount =
+      this.latestPeopleCounts.get(chart.id) ?? flattenTree(chart.workingTree).length;
     metaEl.textContent = this.formatChartMeta(peopleCount, versionCount);
     infoEl.appendChild(metaEl);
 
@@ -359,14 +363,37 @@ export class ChartEditor {
   }
 
   private updateChartMeta(chartId: string, peopleCount: number): void {
+    this.latestPeopleCounts.set(chartId, peopleCount);
+    if (this.refreshInProgress) {
+      this.pendingPeopleCounts.set(chartId, peopleCount);
+      return;
+    }
+    this.applyChartMetaUpdate(chartId, peopleCount);
+  }
+
+  private applyPendingChartMetaUpdates(): void {
+    const pendingPeopleCounts = Array.from(this.pendingPeopleCounts);
+    this.pendingPeopleCounts.clear();
+    for (const [chartId, peopleCount] of pendingPeopleCounts) {
+      this.applyChartMetaUpdate(chartId, peopleCount);
+    }
+  }
+
+  private applyChartMetaUpdate(chartId: string, peopleCount: number): void {
     const chartItem = Array.from(
       this.chartListEl.querySelectorAll<HTMLElement>('[data-chart-id]'),
     ).find((item) => item.dataset.chartId === chartId);
     const metaEl = chartItem?.querySelector<HTMLElement>('.chart-item-meta');
-    if (!metaEl) return;
+    if (!metaEl) {
+      console.warn(`Chart row not found for working-tree save: ${chartId}`);
+      return;
+    }
 
-    const versionCount = Number(metaEl.dataset.versionCount);
-    if (!Number.isFinite(versionCount)) return;
+    const versionCount = this.versionCounts.get(chartId);
+    if (versionCount === undefined) {
+      console.warn(`Version count not found for chart: ${chartId}`);
+      return;
+    }
     metaEl.textContent = this.formatChartMeta(peopleCount, versionCount);
   }
 

--- a/src/editor/chart-editor.ts
+++ b/src/editor/chart-editor.ts
@@ -66,6 +66,7 @@ export class ChartEditor {
   private viewingVersionId: string | null = null;
 
   private unsubscribe: (() => void) | null = null;
+  private unsubscribeWorkingTreeSaved: (() => void) | null = null;
   private errorTimers: ReturnType<typeof setTimeout>[] = [];
   private refreshInProgress = false;
   private refreshQueued = false;
@@ -85,6 +86,9 @@ export class ChartEditor {
 
     this.build();
     this.unsubscribe = this.chartStore.onChange(() => this.refresh());
+    this.unsubscribeWorkingTreeSaved = this.chartStore.onWorkingTreeSaved(
+      ({ chartId, peopleCount }) => this.updateChartMeta(chartId, peopleCount),
+    );
   }
 
   async refresh(): Promise<void> {
@@ -108,6 +112,10 @@ export class ChartEditor {
     if (this.unsubscribe) {
       this.unsubscribe();
       this.unsubscribe = null;
+    }
+    if (this.unsubscribeWorkingTreeSaved) {
+      this.unsubscribeWorkingTreeSaved();
+      this.unsubscribeWorkingTreeSaved = null;
     }
     for (const t of this.errorTimers) clearTimeout(t);
     this.errorTimers = [];
@@ -299,9 +307,8 @@ export class ChartEditor {
     const metaEl = document.createElement('div');
     metaEl.className = 'chart-item-meta';
     const peopleCount = flattenTree(chart.workingTree).length;
-    const vSuffix =
-      versionCount === 1 ? t('chart_editor.version_suffix') : t('chart_editor.versions_suffix');
-    metaEl.textContent = `${peopleCount} ${t('chart_editor.people_suffix')} · ${versionCount} ${vSuffix}`;
+    metaEl.dataset.versionCount = String(versionCount);
+    metaEl.textContent = this.formatChartMeta(peopleCount, versionCount);
     infoEl.appendChild(metaEl);
 
     item.appendChild(infoEl);
@@ -343,6 +350,24 @@ export class ChartEditor {
     }
 
     return item;
+  }
+
+  private formatChartMeta(peopleCount: number, versionCount: number): string {
+    const vSuffix =
+      versionCount === 1 ? t('chart_editor.version_suffix') : t('chart_editor.versions_suffix');
+    return `${peopleCount} ${t('chart_editor.people_suffix')} · ${versionCount} ${vSuffix}`;
+  }
+
+  private updateChartMeta(chartId: string, peopleCount: number): void {
+    const chartItem = Array.from(
+      this.chartListEl.querySelectorAll<HTMLElement>('[data-chart-id]'),
+    ).find((item) => item.dataset.chartId === chartId);
+    const metaEl = chartItem?.querySelector<HTMLElement>('.chart-item-meta');
+    if (!metaEl) return;
+
+    const versionCount = Number(metaEl.dataset.versionCount);
+    if (!Number.isFinite(versionCount)) return;
+    metaEl.textContent = this.formatChartMeta(peopleCount, versionCount);
   }
 
   // ── Render version list ────────────────────────────────

--- a/src/store/chart-store.ts
+++ b/src/store/chart-store.ts
@@ -12,6 +12,7 @@ import { validateTree } from './org-store';
 import { generateId } from '../utils/id';
 import { EventEmitter } from '../utils/event-emitter';
 import { type IStorage, browserStorage } from '../utils/storage';
+import { flattenTree } from '../utils/tree';
 import { t } from '../i18n';
 
 const DEFAULT_ROOT: OrgNode = {
@@ -26,6 +27,17 @@ const LS_CAT_KEY = 'arbol-categories';
 const VALID_LEVEL_DISPLAY_MODES: ReadonlySet<string> = new Set(['original', 'mapped']);
 
 const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+export interface WorkingTreeSavedEvent {
+  chartId: string;
+  peopleCount: number;
+}
+
+class WorkingTreeSavedEmitter extends EventEmitter<WorkingTreeSavedEvent> {
+  emitSaved(event: WorkingTreeSavedEvent): void {
+    this.emit(event);
+  }
+}
 
 function isValidCategory(c: unknown): c is ColorCategory {
   if (typeof c !== 'object' || c === null) return false;
@@ -116,6 +128,7 @@ export class ChartStore extends EventEmitter {
   private lastSavedTree: string | null = null;
   private savedMutationVersion: number | null = null;
   private storage: IStorage;
+  private workingTreeSavedEmitter = new WorkingTreeSavedEmitter();
 
   constructor(db: ChartDB, storage: IStorage = browserStorage) {
     super();
@@ -349,6 +362,10 @@ export class ChartStore extends EventEmitter {
   // Working tree persistence
   // ---------------------------------------------------------------------------
 
+  onWorkingTreeSaved(listener: (event: WorkingTreeSavedEvent) => void): () => void {
+    return this.workingTreeSavedEmitter.onChange(listener);
+  }
+
   async saveWorkingTree(
     tree: OrgNode,
     categories: ColorCategory[],
@@ -356,6 +373,7 @@ export class ChartStore extends EventEmitter {
     levelData?: { levelMappings: LevelMapping[]; levelDisplayMode: LevelDisplayMode },
   ): Promise<void> {
     if (!this.activeChartId) throw new Error('No active chart');
+    const chartId = this.activeChartId;
 
     const patch: Partial<Omit<ChartRecord, 'id'>> = {
       workingTree: tree,
@@ -366,9 +384,10 @@ export class ChartStore extends EventEmitter {
       patch.levelMappings = levelData.levelMappings;
       patch.levelDisplayMode = levelData.levelDisplayMode;
     }
-    await this.db.patchChart(this.activeChartId, patch);
+    await this.db.patchChart(chartId, patch);
     this.savedMutationVersion = mutationVersion ?? null;
     this.lastSavedTree = mutationVersion !== undefined ? null : JSON.stringify(tree);
+    this.workingTreeSavedEmitter.emitSaved({ chartId, peopleCount: flattenTree(tree).length });
   }
 
   isDirty(currentTree: OrgNode, mutationVersion?: number): boolean {

--- a/src/store/chart-store.ts
+++ b/src/store/chart-store.ts
@@ -28,6 +28,11 @@ const VALID_LEVEL_DISPLAY_MODES: ReadonlySet<string> = new Set(['original', 'map
 
 const HEX_COLOR_RE = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
+/**
+ * Lightweight metadata emitted after a working-tree patch is persisted.
+ * This is separate from `onChange` so the 500ms-debounced autosave can update
+ * people counts without triggering a full chart-list refresh.
+ */
 export interface WorkingTreeSavedEvent {
   chartId: string;
   peopleCount: number;
@@ -362,6 +367,11 @@ export class ChartStore extends EventEmitter {
   // Working tree persistence
   // ---------------------------------------------------------------------------
 
+  /**
+   * Subscribes to the lightweight event emitted after `saveWorkingTree` finishes
+   * persisting. Unlike `onChange`, it lets debounced autosaves patch sidebar
+   * metadata without rebuilding the complete chart and version lists.
+   */
   onWorkingTreeSaved(listener: (event: WorkingTreeSavedEvent) => void): () => void {
     return this.workingTreeSavedEmitter.onChange(listener);
   }

--- a/tests/editor/chart-editor-working-tree.test.ts
+++ b/tests/editor/chart-editor-working-tree.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ChartEditor, type ChartEditorOptions } from '../../src/editor/chart-editor';
+import { t } from '../../src/i18n';
+import { OrgStore } from '../../src/store/org-store';
+import type { ChartRecord, OrgNode, VersionRecord } from '../../src/types';
+
+vi.mock('../../src/ui/input-dialog', () => ({
+  showInputDialog: vi.fn().mockResolvedValue('Snapshot'),
+}));
+
+function makeTree(id: string, peopleCount: number): OrgNode {
+  return {
+    id,
+    name: `${id} root`,
+    title: 'CEO',
+    children: Array.from({ length: peopleCount - 1 }, (_, index) => ({
+      id: `${id}-person-${index + 1}`,
+      name: `Person ${index + 1}`,
+      title: 'Engineer',
+    })),
+  };
+}
+
+function makeChart(id: string, peopleCount: number): ChartRecord {
+  return {
+    id,
+    name: `${id} chart`,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    workingTree: makeTree(id, peopleCount),
+    categories: [],
+  };
+}
+
+function expectedMeta(peopleCount: number, versionCount: number): string {
+  const versionSuffix =
+    versionCount === 1 ? t('chart_editor.version_suffix') : t('chart_editor.versions_suffix');
+  return `${peopleCount} ${t('chart_editor.people_suffix')} · ${versionCount} ${versionSuffix}`;
+}
+
+function createChartStore(charts: ChartRecord[]) {
+  let activeChartId = charts[0]?.id ?? null;
+  let versions: VersionRecord[] = [];
+  let workingTreeSavedListener: ((event: { chartId: string; peopleCount: number }) => void) | null =
+    null;
+
+  return {
+    getCharts: vi.fn(async () => charts),
+    getActiveChartId: vi.fn(() => activeChartId),
+    getVersions: vi.fn(async (chartId?: string) =>
+      versions.filter((version) => version.chartId === (chartId ?? activeChartId)),
+    ),
+    onChange: vi.fn(() => () => {}),
+    onWorkingTreeSaved: vi.fn(
+      (listener: (event: { chartId: string; peopleCount: number }) => void) => {
+        workingTreeSavedListener = listener;
+        return () => {
+          workingTreeSavedListener = null;
+        };
+      },
+    ),
+    switchChart: vi.fn(async (chartId: string) => {
+      const chart = charts.find((candidate) => candidate.id === chartId)!;
+      activeChartId = chartId;
+      return chart;
+    }),
+    saveWorkingTree: vi.fn(async (tree: OrgNode) => {
+      const chart = charts.find((candidate) => candidate.id === activeChartId)!;
+      chart.workingTree = tree;
+      workingTreeSavedListener?.({
+        chartId: chart.id,
+        peopleCount: 1 + (tree.children?.length ?? 0),
+      });
+    }),
+    saveVersion: vi.fn(async (name: string, tree: OrgNode) => {
+      const version: VersionRecord = {
+        id: `version-${versions.length + 1}`,
+        chartId: activeChartId!,
+        name,
+        createdAt: new Date().toISOString(),
+        tree,
+      };
+      versions = [...versions, version];
+      return version;
+    }),
+    restoreVersion: vi.fn(
+      async (versionId: string) => versions.find((version) => version.id === versionId)!.tree,
+    ),
+    createChart: vi.fn(),
+    getActiveChart: vi.fn(async () => charts.find((candidate) => candidate.id === activeChartId)),
+    deleteChart: vi.fn(),
+    renameChart: vi.fn(),
+    duplicateChart: vi.fn(),
+    deleteVersion: vi.fn(),
+    isDirty: vi.fn(() => false),
+  };
+}
+
+describe('ChartEditor working-tree people counts', () => {
+  let editor: ChartEditor | null = null;
+  let container: HTMLDivElement | null = null;
+
+  afterEach(() => {
+    editor?.destroy();
+    container?.remove();
+    editor = null;
+    container = null;
+  });
+
+  async function render(charts: ChartRecord[]) {
+    const chartStore = createChartStore(charts);
+    const orgStore = new OrgStore(charts[0].workingTree);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    editor = new ChartEditor({
+      container,
+      chartStore: chartStore as unknown as ChartEditorOptions['chartStore'],
+      onChartSwitch: (chart) => orgStore.replaceTree(chart.workingTree),
+      onVersionRestore: (tree) => orgStore.replaceTree(tree),
+      onVersionView: vi.fn(),
+      onVersionCompare: vi.fn(),
+      getCurrentTree: () => orgStore.getTree(),
+      getCurrentCategories: () => [],
+      onBeforeSwitch: vi.fn().mockResolvedValue(true),
+    });
+
+    await vi.waitFor(() => {
+      expect(container!.querySelector('[data-chart-id]')).not.toBeNull();
+    });
+    return { chartStore, orgStore };
+  }
+
+  function getChartRow(chartId: string): HTMLElement {
+    return container!.querySelector<HTMLElement>(`[data-chart-id="${chartId}"]`)!;
+  }
+
+  function getMeta(chartId: string): HTMLElement {
+    return getChartRow(chartId).querySelector<HTMLElement>('.chart-item-meta')!;
+  }
+
+  it('patches meta in place after the debounced working-tree save without reloading lists', async () => {
+    const chart = makeChart('active', 1);
+    const { chartStore, orgStore } = await render([chart]);
+    const rowBeforeSave = getChartRow(chart.id);
+    rowBeforeSave.focus();
+    chartStore.getCharts.mockClear();
+    chartStore.getVersions.mockClear();
+    const replacementTree = makeTree('sample', 3);
+
+    orgStore.fromJSON(JSON.stringify(replacementTree));
+    await chartStore.saveWorkingTree(orgStore.getTree());
+
+    const rowAfterSave = getChartRow(chart.id);
+    expect(chartStore.onWorkingTreeSaved).toHaveBeenCalledOnce();
+    expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 0));
+    expect(rowAfterSave).toBe(rowBeforeSave);
+    expect(document.activeElement).toBe(rowBeforeSave);
+    expect(chartStore.getCharts).not.toHaveBeenCalled();
+    expect(chartStore.getVersions).not.toHaveBeenCalled();
+  });
+
+  it('shows the target chart people count immediately after switching charts', async () => {
+    const initial = makeChart('initial', 1);
+    const target = makeChart('larger', 4);
+    await render([initial, target]);
+
+    getChartRow(target.id).click();
+
+    await vi.waitFor(() => {
+      expect(getChartRow(target.id).classList.contains('active')).toBe(true);
+      expect(getMeta(target.id).textContent).toBe(expectedMeta(4, 0));
+    });
+  });
+
+  it('keeps people and version counts correct after saving and restoring a version', async () => {
+    const chart = makeChart('active', 1);
+    const { chartStore, orgStore } = await render([chart]);
+    orgStore.fromJSON(JSON.stringify(makeTree('saved', 3)));
+    await chartStore.saveWorkingTree(orgStore.getTree());
+
+    container!.querySelector<HTMLButtonElement>('.version-section-header button')!.click();
+
+    await vi.waitFor(() => {
+      expect(chartStore.saveVersion).toHaveBeenCalledOnce();
+      expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 1));
+    });
+    const version = await chartStore.saveVersion.mock.results[0].value;
+
+    orgStore.fromJSON(JSON.stringify(makeTree('changed', 2)));
+    await chartStore.saveWorkingTree(orgStore.getTree());
+    expect(getMeta(chart.id).textContent).toBe(expectedMeta(2, 1));
+
+    await editor!.restoreVersion(version);
+    await chartStore.saveWorkingTree(orgStore.getTree());
+
+    expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 1));
+  });
+});

--- a/tests/editor/chart-editor-working-tree.test.ts
+++ b/tests/editor/chart-editor-working-tree.test.ts
@@ -185,6 +185,34 @@ describe('ChartEditor working-tree people counts', () => {
     expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 0));
   });
 
+  it('quietly retains a saved count while the active chart is filtered out', async () => {
+    const chart = makeChart('active', 1);
+    const { chartStore, orgStore } = await render([chart]);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const searchInput = container!.querySelector<HTMLInputElement>('.chart-search')!;
+      searchInput.value = 'does not match';
+      searchInput.dispatchEvent(new Event('input'));
+      await vi.waitFor(() => {
+        expect(container!.querySelector('[data-chart-id]')).toBeNull();
+      });
+
+      const replacementTree = makeTree('saved-while-filtered', 3);
+      orgStore.fromJSON(JSON.stringify(replacementTree));
+      await expect(chartStore.saveWorkingTree(orgStore.getTree())).resolves.toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+
+      searchInput.value = '';
+      searchInput.dispatchEvent(new Event('input'));
+      await vi.waitFor(() => {
+        expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 0));
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('shows the target chart people count immediately after switching charts', async () => {
     const initial = makeChart('initial', 1);
     const target = makeChart('larger', 4);

--- a/tests/editor/chart-editor-working-tree.test.ts
+++ b/tests/editor/chart-editor-working-tree.test.ts
@@ -43,6 +43,9 @@ function createChartStore(charts: ChartRecord[]) {
   let versions: VersionRecord[] = [];
   let workingTreeSavedListener: ((event: { chartId: string; peopleCount: number }) => void) | null =
     null;
+  const unsubscribeWorkingTreeSaved = vi.fn(() => {
+    workingTreeSavedListener = null;
+  });
 
   return {
     getCharts: vi.fn(async () => charts),
@@ -54,11 +57,10 @@ function createChartStore(charts: ChartRecord[]) {
     onWorkingTreeSaved: vi.fn(
       (listener: (event: { chartId: string; peopleCount: number }) => void) => {
         workingTreeSavedListener = listener;
-        return () => {
-          workingTreeSavedListener = null;
-        };
+        return unsubscribeWorkingTreeSaved;
       },
     ),
+    unsubscribeWorkingTreeSaved,
     switchChart: vi.fn(async (chartId: string) => {
       const chart = charts.find((candidate) => candidate.id === chartId)!;
       activeChartId = chartId;
@@ -208,6 +210,29 @@ describe('ChartEditor working-tree people counts', () => {
       await vi.waitFor(() => {
         expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 0));
       });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('unsubscribes working-tree save updates when destroyed', async () => {
+    const chart = makeChart('active', 1);
+    const { chartStore, orgStore } = await render([chart]);
+    const renderedMeta = getMeta(chart.id);
+    const originalMeta = renderedMeta.textContent;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      editor!.destroy();
+      editor = null;
+      expect(chartStore.unsubscribeWorkingTreeSaved).toHaveBeenCalledOnce();
+
+      const replacementTree = makeTree('saved-after-destroy', 3);
+      orgStore.fromJSON(JSON.stringify(replacementTree));
+      await chartStore.saveWorkingTree(orgStore.getTree());
+
+      expect(renderedMeta.textContent).toBe(originalMeta);
+      expect(warn).not.toHaveBeenCalled();
     } finally {
       warn.mockRestore();
     }

--- a/tests/editor/chart-editor-working-tree.test.ts
+++ b/tests/editor/chart-editor-working-tree.test.ts
@@ -159,6 +159,32 @@ describe('ChartEditor working-tree people counts', () => {
     expect(chartStore.getVersions).not.toHaveBeenCalled();
   });
 
+  it('keeps a saved people count when a stale refresh snapshot resolves afterward', async () => {
+    const chart = makeChart('active', 1);
+    const { chartStore, orgStore } = await render([chart]);
+    let resolveCharts!: (charts: ChartRecord[]) => void;
+    const staleSnapshot = makeChart('active', 1);
+    chartStore.getCharts.mockImplementationOnce(
+      () =>
+        new Promise<ChartRecord[]>((resolve) => {
+          resolveCharts = resolve;
+        }),
+    );
+
+    const refresh = editor!.refresh();
+    await vi.waitFor(() => {
+      expect(container!.querySelector('[data-chart-id]')).toBeNull();
+    });
+
+    const replacementTree = makeTree('saved-during-refresh', 3);
+    orgStore.fromJSON(JSON.stringify(replacementTree));
+    await chartStore.saveWorkingTree(orgStore.getTree());
+    resolveCharts([staleSnapshot]);
+    await refresh;
+
+    expect(getMeta(chart.id).textContent).toBe(expectedMeta(3, 0));
+  });
+
   it('shows the target chart people count immediately after switching charts', async () => {
     const initial = makeChart('initial', 1);
     const target = makeChart('larger', 4);

--- a/tests/editor/chart-editor.test.ts
+++ b/tests/editor/chart-editor.test.ts
@@ -61,6 +61,7 @@ function mockChartStore(charts: ChartRecord[] = [], versions: VersionRecord[] = 
     getActiveChartId: vi.fn().mockReturnValue(charts[0]?.id ?? null),
     getVersions: vi.fn().mockResolvedValue(versions),
     onChange: vi.fn().mockReturnValue(() => {}),
+    onWorkingTreeSaved: vi.fn().mockReturnValue(() => {}),
     createChart: vi.fn().mockResolvedValue(charts[0] ?? makeChart()),
     switchChart: vi.fn().mockResolvedValue(charts[0] ?? makeChart()),
     getActiveChart: vi.fn().mockImplementation(async () => charts[0]),

--- a/tests/store/chart-store.test.ts
+++ b/tests/store/chart-store.test.ts
@@ -693,6 +693,31 @@ describe('ChartStore', () => {
       expect(listener).toHaveBeenCalled();
     });
 
+    it('onWorkingTreeSaved reports the saved chart and people count without a full change', async () => {
+      const fullChangeListener = vi.fn();
+      const workingTreeListener = vi.fn();
+      store.onChange(fullChangeListener);
+      const observableStore = store as ChartStore & {
+        onWorkingTreeSaved: (
+          listener: (event: { chartId: string; peopleCount: number }) => void,
+        ) => () => void;
+      };
+      observableStore.onWorkingTreeSaved(workingTreeListener);
+      const chartId = store.getActiveChartId();
+      const tree = makeTree({
+        children: [
+          makeTree({ id: 'child-1', name: 'Bob' }),
+          makeTree({ id: 'child-2', name: 'Carol' }),
+        ],
+      });
+
+      await store.saveWorkingTree(tree, []);
+
+      expect(workingTreeListener).toHaveBeenCalledOnce();
+      expect(workingTreeListener).toHaveBeenCalledWith({ chartId, peopleCount: 3 });
+      expect(fullChangeListener).not.toHaveBeenCalled();
+    });
+
     it('onChange returns an unsubscribe function that works', async () => {
       const listener = vi.fn();
       const unsub = store.onChange(listener);


### PR DESCRIPTION
## Summary
Fixes the last P0 from the July 2026 UX review (milestone M1-iii): after loading the sample org or replacing the tree via import, the sidebar chart card was stuck at "1 people · 0 versions" for the whole session while the canvas and footer showed real counts.

Root cause: `ChartStore.saveWorkingTree()` persisted without emitting, and the sidebar only refreshed on `onChange`. Fix adds a dedicated lightweight `onWorkingTreeSaved` notification consumed by `ChartEditor` to patch the row's meta text **in place** — no chart/version list re-render on debounced autosaves, row identity and keyboard focus preserved (protects #121's focusable rows).

Implemented by Codex with TDD (failing tests confirmed at the test commit); type-check, lint, and full suite pass.

## Test plan
- [x] `npm run type-check && npm run lint && npm test`
- [x] Regression tests: unchanged row identity, preserved focus, zero list reloads during in-place update; counts correct after chart switch and version ops
- [ ] Manual: Load Sample Org → sidebar count updates to 19 people

🤖 Generated with [Claude Code](https://claude.com/claude-code)