### PR TITLE
docs: refresh README, consolidate first-run, auto-map import headers, preserve Direction B

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,7 @@
+# M8b implementation plan
+
+1. Refresh the README architecture and product language without documenting Trash.
+2. Preserve the July 2026 Direction B exploration and copy both interactive mocks with the required production-chart disclaimer.
+3. Add a failing first-run test, then consolidate first-run onboarding into one welcome dialog while retaining help-dialog sample loading.
+4. Add failing import auto-mapping tests, then support normalized common header synonyms.
+5. Run type-check, lint, and the full test suite; inspect commits and artifacts for the final handoff.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,7 +1,0 @@
-# M8b implementation plan
-
-1. Refresh the README architecture and product language without documenting Trash.
-2. Preserve the July 2026 Direction B exploration and copy both interactive mocks with the required production-chart disclaimer.
-3. Add a failing first-run test, then consolidate first-run onboarding into one welcome dialog while retaining help-dialog sample loading.
-4. Add failing import auto-mapping tests, then support normalized common header synonyms.
-5. Run type-check, lint, and the full test suite; inspect commits and artifacts for the final handoff.

--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ An interactive org chart editor for the browser — manage multiple org charts w
 ## Features
 
 - **Multiple org charts** — create, rename, switch between, and delete independent org charts
-- **Version snapshots** — save named point-in-time snapshots; view read-only, restore, or delete
-- **Version comparison** — side-by-side or merged diff view with diff badges (added/removed/moved/modified), click-to-select cross-highlighting, and hover cross-pane tracking
+- **Version history** — save named versions, preview any version read-only, restore safely, or delete versions you no longer need
+- **Version comparison** — compare the Current chart with a saved version in side-by-side or merged views, with delta chips for added, removed, moved, and modified people
 - **Per-chart color categories** — each chart has its own set of color categories
 - **Dual-track level mappings** — same level maps to different titles for Managers vs ICs, with auto-detection from tree structure
 - **Pinned titles** — manually override any node's title to prevent level mapping from changing it
 - **Category & level mapping presets** — save reusable presets, copy from other charts, pick presets when creating new charts
-- **Chart name in header** — editable name with dirty-state indicator (●) and quick save button (💾)
+- **Always-visible version actions** — the Current chart, Save a version, and Version history controls stay within reach in the app chrome
 - **IndexedDB storage** — org data stored in IndexedDB for capacity across multiple charts and versions
 - **Import creates or replaces** — importing CSV/JSON or re-importing `.arbol.json` ChartBundle exports asks whether to create a new chart or replace the current one
-- **Autosave and restore safety** — changes save automatically, and restoring a version first creates an automatic safety version when needed
+- **Autosave and restore safety** — the Current chart saves automatically, and restoring a version first creates a safety-net version when needed
 - **Accessible org chart** — full keyboard navigation (arrow keys, Enter, Space), ARIA tree semantics, screen reader announcements
 - **Mobile responsive** — collapsible sidebar on tablet/phone, touch-friendly 44px targets, works at 200% zoom
 - **i18n ready** — translation infrastructure with 1,180+ keys, Spanish locale, RTL-ready CSS logical properties
-- **First-time guidance** — help dialog with Getting Started guide for new users, contextual "no results" hints
+- **First-time guidance** — one welcome dialog lets new users load the sample org chart or start empty, with a direct pointer to Import
 - **Loading indicators** — visual feedback for exports, imports, chart switching
 - Interactive hierarchical org chart visualization
-- Four sidebar tabs: People (add/edit), Import (files, paste, JSON editor, `.arbol.json` ChartBundle re-import, text normalization), Settings (presets, categories, fine-tuning), Charts (chart & version management)
+- Focused editing surfaces — select a card to inspect its properties, use the Import wizard for CSV/Excel/JSON and `.arbol.json` bundles, and manage charts and versions from the app chrome
 - Text normalization — normalize name/title casing (Title Case, UPPERCASE, lowercase) on import or for the existing org chart
 - Per-node color categories (Open Position, Offer Pending, Future Start + custom)
 - Color category legend on the chart (SVG overlay, included in PPTX export)
@@ -35,7 +35,7 @@ An interactive org chart editor for the browser — manage multiple org charts w
 - PowerPoint export (.pptx) with editable shapes, connectors, per-node category colors, and legend
 - Advisor role support with special 2-column layout
 - Smart M1 detection (compact layout for manager groups)
-- 20+ customizable renderer settings (dimensions, spacing, typography, colors, rounded corners, font family, text alignment)
+- Six searchable settings groups covering presets, layout, appearance, cards & badges, levels & categories, and data & backup
 - Dark/light theme with 10 presets (including Ocean Teal and Stone)
 - Full undo/redo (50-entry stack)
 - Search & highlight by name/title
@@ -93,6 +93,20 @@ Output goes to `dist/`.
 ## Tech Stack
 
 TypeScript, Vite, D3.js, pptxgenjs — no UI framework, no backend.
+
+## Architecture
+
+Arbol is a vanilla TypeScript application with deliberately small, composable UI surfaces:
+
+- **D3-owned SVG canvas** — D3 computes the tree layout and owns chart rendering, zoom, keyboard navigation, comparison views, and export-ready SVG output.
+- **SVG icon system** — app chrome and actions use the shared `createIcon` system instead of text glyphs or emoji controls.
+- **Design-token CSS** — colors, spacing, typography, surfaces, and a semantic z-scale are defined as tokens so dialogs, panels, banners, and floating controls layer consistently.
+- **Consolidated dialog utilities** — modal surfaces share overlay creation, panel chrome, focus trapping, Escape handling, focus restoration, and stacking behavior.
+- **Inspector-first editing** — **Edit** opens the property panel for complete changes; **Quick edit** keeps the lightweight name-and-title editor inline on the chart.
+- **Searchable settings** — one modal organizes settings into six groups and filters sections without replacing the underlying renderer controls.
+- **Consumer-friendly versions** — the UI consistently uses **Version history**, **Current chart**, **Save a version**, and **Preview**, with restore safety-net language and delta chips in comparisons.
+
+State is split by responsibility: stores own chart data and browser persistence, controllers coordinate interaction modes, editors assemble workflows, and UI modules provide focused panels and dialogs. Org charts and saved versions remain local in IndexedDB; preferences and lightweight configuration use localStorage.
 
 ## Enterprise Configuration
 
@@ -156,13 +170,13 @@ src/
 ├── constants/   # Renderer default values
 ├── controllers/ # Focus mode, search, selection state
 ├── data/        # Built-in sample org chart
-├── editor/      # Sidebar tab editors (People, Import, Settings, Charts, Analytics)
+├── editor/      # Editing workflows and settings panels
 ├── export/      # PowerPoint, SVG, and PNG export
 ├── i18n/        # Internationalization (translations, locale management)
-├── init/        # App initialization helpers
+├── init/        # App wiring, toolbar, shortcuts, and interaction handlers
 ├── renderer/    # D3-based chart rendering, layout, and keyboard navigation
 ├── store/       # State management, IndexedDB, undo/redo
-├── ui/          # Panels, dialogs, controls, and accessibility utilities
+├── ui/          # Icon-based chrome, panels, dialogs, controls, and accessibility utilities
 └── utils/       # Shared helpers and types
 ```
 

--- a/docs/design/future-directions.md
+++ b/docs/design/future-directions.md
@@ -1,0 +1,37 @@
+<!-- The chart-canvas areas in these mocks are illustrative stand-ins. The production chart rendering, style presets, and layout engine are final as-is (owner decision, 2026-07-16). -->
+
+# Future design directions
+
+## Context
+
+A full UX review on 2026-07-16 explored two directions for Arbol. Direction A, **Refined Arbol**, evolved the existing product and was implemented through milestones M1–M9. Direction B, **Arbol Studio**, proposed a more fundamental overhaul. It was not selected for implementation, but its strongest ideas are preserved here as future inspiration.
+
+The chart-canvas areas in both interactive mocks are illustrative stand-ins. The production chart rendering, style presets, and layout engine are final as-is (owner decision, 2026-07-16).
+
+## Direction B: Arbol Studio
+
+Arbol Studio treated organization design as a focused working environment rather than a collection of separate management screens. Four signature ideas defined the direction:
+
+- **Version timeline** — a horizontal, milestone-first path through saved versions. This made time and change legible at a glance and turned version navigation into a primary part of the workspace instead of a secondary list.
+- **Command-first chrome** — the command palette became the primary surface for navigation and actions. This reduced persistent chrome, rewarded keyboard use, and gave infrequent commands one consistent home.
+- **Compare as a mode** — comparison became a first-class view mode rather than a dialog-driven task. Unchanged people were dimmed so meaningful deltas carried the visual weight, supporting fast review of organizational change.
+- **Icon rail navigation** — a compact left rail replaced header clutter. Stable destinations stayed visible while the top of the workspace remained available for chart context, version state, and mode-specific actions.
+
+## Ideas carried into Refined Arbol
+
+Direction A remained an evolution of the existing product, but Direction B influenced several shipped details:
+
+- Consumer version vocabulary: **Version history**, **Current chart**, **Save a version**, and **Preview**
+- Delta chips that summarize added, removed, moved, and modified people
+- Always-visible version actions in the app chrome
+- Search within the six-group settings modal
+
+## Artifacts
+
+The external artifacts are private and may require access to the original review workspace:
+
+- [Full UX review report](https://claude.ai/code/artifact/f39ac6bc-8483-4852-aad5-63c4cc1683be)
+- [Direction A: Refined Arbol](https://claude.ai/code/artifact/4a56c195-fb93-46e5-8c8a-b55ab2969b58)
+- [Direction B: Arbol Studio](https://claude.ai/code/artifact/255f85d5-8b5b-4415-a159-5e26c6a18bd0)
+
+Local interactive copies are preserved in [`mocks/direction-a.html`](mocks/direction-a.html) and [`mocks/direction-b.html`](mocks/direction-b.html).

--- a/docs/design/mocks/direction-a.html
+++ b/docs/design/mocks/direction-a.html
@@ -1,0 +1,1587 @@
+<!-- The chart-canvas areas in this mock are illustrative stand-ins. The production chart rendering, style presets, and layout engine are final as-is (owner decision, 2026-07-16). -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<!-- interactive: #theme-toggle, #palette-btn, #settings-btn, .settings-nav button, #settings-close, #settings-cancel, #settings-done, #inspector-close, #node-marcus, #palette-close -->
+<title>Arbol — Refined (Direction A)</title>
+<style>
+  /* ============================================================
+     Arbol — "Refined Arbol" (Direction A)
+     Token system: one 6-step type scale, 4px spacing, component
+     radii, subtle/default/strong borders. Dark is default.
+     ============================================================ */
+
+  #app {
+    /* ---- Palette : DARK (default) ---- */
+    --bg-base:      #0b1120;
+    --bg-canvas:    #0a0f1d;
+    --bg-surface:   #101a2c;
+    --bg-elevated:  #16223a;
+    --bg-hover:     #1c2a45;
+    --bg-active:    #243452;
+    --bg-well:      rgba(20,184,166,0.045);
+
+    --border-subtle: rgba(148,163,184,0.10);
+    --border-default:rgba(148,163,184,0.17);
+    --border-strong: rgba(148,163,184,0.30);
+
+    --text-primary:  #e8eefb;
+    --text-secondary:#9db0cc;
+    --text-tertiary: #67789a;
+
+    --accent:        #14b8a6;
+    --accent-hover:  #2dd4bf;
+    --accent-text:   #5eead4;
+    --accent-strong: #0d9488;
+    --accent-muted:  rgba(20,184,166,0.14);
+    --accent-glow:   rgba(20,184,166,0.30);
+    --on-accent:     #04231f;
+
+    --cat-amber:  #f5b31b;
+    --cat-blue:   #4cb8f5;
+    --cat-violet: #a78bfa;
+    --amber-muted: rgba(245,179,27,0.16);
+    --blue-muted:  rgba(76,184,245,0.16);
+
+    --danger:      #f4677f;
+    --danger-muted:rgba(244,103,127,0.14);
+    --success:     #34d399;
+
+    --grid-line:  rgba(148,163,184,0.055);
+    --grid-major: rgba(148,163,184,0.09);
+    --card-fill:  #17243d;
+
+    --shadow-sm: 0 1px 2px rgba(0,0,0,.4);
+    --shadow-md: 0 6px 20px rgba(0,0,0,.45), 0 2px 6px rgba(0,0,0,.3);
+    --shadow-lg: 0 22px 60px rgba(0,0,0,.6), 0 8px 20px rgba(0,0,0,.4);
+
+    /* ---- Type scale (6 steps) ---- */
+    --fs-xs: 11px;
+    --fs-sm: 12.5px;
+    --fs-md: 13.5px;
+    --fs-lg: 15px;
+    --fs-xl: 19px;
+    --fs-2xl: 25px;
+
+    --fw-normal: 400;
+    --fw-medium: 500;
+    --fw-semi:   600;
+    --fw-bold:   700;
+
+    /* ---- Spacing (4px scale) ---- */
+    --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px;
+    --s6:24px; --s7:32px; --s8:40px; --s9:48px;
+
+    /* ---- Radii ---- */
+    --r-xs:5px; --r-sm:7px; --r-md:9px; --r-lg:12px; --r-xl:16px; --r-full:999px;
+
+    /* ---- Layout ---- */
+    --sidebar-w: 264px;
+    --inspector-w: 344px;
+    --header-h: 54px;
+
+    --ease: cubic-bezier(.22,1,.36,1);
+    --t-fast: 110ms var(--ease);
+    --t: 200ms var(--ease);
+
+    font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    color: var(--text-primary);
+    color-scheme: dark;
+  }
+
+  #app[data-theme="light"] {
+    --bg-base:      #eef2f8;
+    --bg-canvas:    #f6f9fc;
+    --bg-surface:   #ffffff;
+    --bg-elevated:  #ffffff;
+    --bg-hover:     #f1f5f9;
+    --bg-active:    #e5ebf3;
+    --bg-well:      rgba(13,148,136,0.05);
+
+    --border-subtle: rgba(15,23,42,0.07);
+    --border-default:rgba(15,23,42,0.13);
+    --border-strong: rgba(15,23,42,0.24);
+
+    --text-primary:  #0f1c31;
+    --text-secondary:#4c5c72;
+    --text-tertiary: #7688a0;
+
+    --accent:        #0d9488;
+    --accent-hover:  #0f766e;
+    --accent-text:   #0b7a70;
+    --accent-strong: #0d9488;
+    --accent-muted:  rgba(13,148,136,0.10);
+    --accent-glow:   rgba(13,148,136,0.20);
+    --on-accent:     #ffffff;
+
+    --cat-amber:  #d98a09;
+    --cat-blue:   #2a7fc4;
+    --cat-violet: #7c5cf0;
+    --amber-muted: rgba(217,138,9,0.14);
+    --blue-muted:  rgba(42,127,196,0.14);
+
+    --danger:      #dc2f4b;
+    --danger-muted:rgba(220,47,75,0.10);
+    --success:     #0f9d6b;
+
+    --grid-line:  rgba(15,23,42,0.045);
+    --grid-major: rgba(15,23,42,0.075);
+    --card-fill:  #ffffff;
+
+    --shadow-sm: 0 1px 2px rgba(15,23,42,.06);
+    --shadow-md: 0 8px 24px rgba(15,23,42,.10), 0 2px 6px rgba(15,23,42,.06);
+    --shadow-lg: 0 24px 60px rgba(15,23,42,.16), 0 8px 20px rgba(15,23,42,.08);
+
+    color-scheme: light;
+  }
+
+  /* ---------- base ---------- */
+  /* Low-specificity resets so component classes always win. */
+  *, *::before, *::after { box-sizing: border-box; }
+  button, input, select, h1, h2, p { margin: 0; }
+  button { padding: 0; background: none; border: none; font: inherit; color: inherit; cursor: pointer; }
+  input, select { font: inherit; color: inherit; }
+  #app {
+    height: 100vh;
+    display: grid;
+    grid-template-rows: var(--header-h) 1fr auto;
+    background: var(--bg-base);
+    overflow: hidden;
+    font-size: var(--fs-md);
+    line-height: 1.45;
+  }
+  #app .icon { width: 17px; height: 17px; flex: none; stroke: currentColor; fill: none;
+    stroke-width: 1.75; stroke-linecap: round; stroke-linejoin: round; }
+  #app .icon-sm { width: 14px; height: 14px; }
+
+  #app :focus-visible {
+    outline: 2px solid var(--accent-hover);
+    outline-offset: 2px;
+    border-radius: var(--r-xs);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    #app *, #app *::before, #app *::after { transition: none !important; animation: none !important; }
+  }
+
+  /* ============================================================ HEADER */
+  .header {
+    display: flex; align-items: center; gap: var(--s5);
+    padding: 0 var(--s5);
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--bg-surface);
+    z-index: 20;
+  }
+  .brand { display: flex; align-items: center; gap: var(--s3); }
+  .wordmark { font-size: var(--fs-xl); font-weight: var(--fw-bold); letter-spacing: -0.02em; }
+  .wordmark b { color: var(--text-primary); font-weight: var(--fw-bold); }
+  .wordmark span { color: var(--accent); }
+  .brand-leaf { width: 26px; height: 26px; border-radius: var(--r-sm);
+    display: grid; place-items: center;
+    background: var(--accent-muted); color: var(--accent-text); }
+  .brand-leaf .icon { width: 16px; height: 16px; }
+
+  .header-center { flex: 1; display: flex; align-items: center; justify-content: center; gap: var(--s4); min-width: 0; }
+  .chart-name { display: flex; align-items: center; gap: var(--s3); min-width: 0; }
+  .chart-name .title {
+    display: inline-flex; align-items: center; gap: var(--s2);
+    padding: 5px var(--s3); border-radius: var(--r-md);
+    font-size: var(--fs-md); font-weight: var(--fw-semi);
+    border: 1px solid transparent; transition: border-color var(--t-fast), background var(--t-fast);
+  }
+  .chart-name .title:hover { border-color: var(--border-default); background: var(--bg-hover); }
+  .chart-name .title .icon { color: var(--text-tertiary); }
+  .pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px var(--s3); border-radius: var(--r-full);
+    font-size: var(--fs-xs); font-weight: var(--fw-semi); letter-spacing: .01em;
+    border: 1px solid transparent; white-space: nowrap;
+  }
+  .pill.unsaved { color: var(--accent-text); background: var(--accent-muted); border-color: rgba(20,184,166,.28); }
+  .pill .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+
+  .cmdk {
+    display: inline-flex; align-items: center; gap: var(--s3);
+    padding: 6px var(--s3) 6px var(--s4);
+    border-radius: var(--r-full);
+    border: 1px solid var(--border-default);
+    background: var(--bg-base);
+    color: var(--text-secondary);
+    font-size: var(--fs-sm);
+    transition: border-color var(--t-fast), color var(--t-fast), background var(--t-fast);
+  }
+  .cmdk:hover { border-color: var(--border-strong); color: var(--text-primary); }
+  .cmdk .icon { width: 15px; height: 15px; }
+  .kbd {
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Consolas, monospace;
+    font-size: 11px; font-weight: var(--fw-semi);
+    padding: 2px 6px; border-radius: var(--r-xs);
+    background: var(--bg-elevated); border: 1px solid var(--border-default);
+    color: var(--text-secondary); line-height: 1;
+  }
+
+  .header-actions { display: flex; align-items: center; gap: 2px; }
+  .hbtn {
+    position: relative;
+    display: grid; place-items: center;
+    width: 34px; height: 34px; border-radius: var(--r-sm);
+    color: var(--text-secondary);
+    transition: background var(--t-fast), color var(--t-fast);
+  }
+  .hbtn:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .hbtn.icon-btn-label::after {
+    content: attr(data-label);
+    position: absolute; top: calc(100% + 8px); left: 50%; transform: translateX(-50%);
+    padding: 4px 8px; border-radius: var(--r-xs);
+    background: var(--bg-active); color: var(--text-primary);
+    font-size: var(--fs-xs); white-space: nowrap; box-shadow: var(--shadow-md);
+    border: 1px solid var(--border-default);
+    opacity: 0; pointer-events: none; transition: opacity var(--t-fast); z-index: 40;
+  }
+  .hbtn.icon-btn-label:hover::after { opacity: 1; }
+  .hdiv { width: 1px; height: 22px; background: var(--border-default); margin: 0 var(--s2); }
+  .theme-icon-moon { display: none; }
+  #app[data-theme="light"] .theme-icon-moon { display: block; }
+  #app[data-theme="light"] .theme-icon-sun  { display: none; }
+
+  /* ============================================================ MAIN */
+  .main {
+    display: grid;
+    grid-template-columns: var(--sidebar-w) minmax(0,1fr) var(--inspector-w);
+    min-height: 0;
+    transition: grid-template-columns var(--t);
+  }
+  #app.inspector-collapsed { --inspector-w: 0px; }
+
+  /* ---------- SIDEBAR ---------- */
+  .sidebar {
+    display: flex; flex-direction: column; min-height: 0;
+    background: var(--bg-surface);
+    border-right: 1px solid var(--border-subtle);
+  }
+  .side-scroll { overflow-y: auto; flex: 1; min-height: 0; }
+  .side-section { padding: var(--s5) var(--s5) var(--s3); }
+  .side-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: var(--s3);
+  }
+  .eyebrow {
+    font-size: var(--fs-xs); font-weight: var(--fw-bold);
+    letter-spacing: .08em; text-transform: uppercase; color: var(--text-tertiary);
+  }
+  .icon-mini {
+    display: grid; place-items: center; width: 24px; height: 24px; border-radius: var(--r-xs);
+    color: var(--text-secondary); transition: background var(--t-fast), color var(--t-fast);
+  }
+  .icon-mini:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+  .search-field {
+    display: flex; align-items: center; gap: var(--s2);
+    padding: 7px var(--s3); border-radius: var(--r-md);
+    background: var(--bg-base); border: 1px solid var(--border-default);
+    color: var(--text-tertiary); margin-bottom: var(--s3);
+  }
+  .search-field .icon { width: 15px; height: 15px; }
+  .search-field input { flex: 1; background: none; border: none; outline: none; font-size: var(--fs-sm);
+    color: var(--text-primary); }
+  .search-field input::placeholder { color: var(--text-tertiary); }
+
+  .chart-row {
+    display: flex; align-items: center; gap: var(--s3);
+    padding: var(--s3); border-radius: var(--r-md);
+    border: 1px solid transparent; margin-bottom: 6px;
+    transition: background var(--t-fast), border-color var(--t-fast);
+    text-align: left; width: 100%;
+  }
+  .chart-row:hover { background: var(--bg-hover); }
+  .chart-row.active {
+    background: var(--accent-muted);
+    border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+    box-shadow: inset 3px 0 0 var(--accent);
+  }
+  .chart-ic {
+    width: 32px; height: 32px; border-radius: var(--r-sm); flex: none;
+    display: grid; place-items: center;
+    background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+    color: var(--accent-text);
+  }
+  .chart-row.active .chart-ic { background: color-mix(in srgb, var(--accent) 22%, var(--bg-elevated)); }
+  .chart-meta { min-width: 0; }
+  .chart-title { display: block; font-size: var(--fs-md); font-weight: var(--fw-semi); color: var(--text-primary);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .chart-sub { display: block; font-size: var(--fs-xs); color: var(--text-tertiary);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+  .divider { height: 1px; background: var(--border-subtle); margin: var(--s2) var(--s5); }
+
+  /* snapshots */
+  .snap-section { padding: var(--s4) var(--s5) var(--s5); }
+  .current-row {
+    display: flex; flex-direction: column; align-items: stretch; gap: var(--s3);
+    padding: var(--s3); border-radius: var(--r-md);
+    background: var(--amber-muted);
+    border: 1px solid rgba(245,179,27,.28);
+    margin-bottom: var(--s3);
+  }
+  .cr-head { display: flex; align-items: flex-start; gap: var(--s3); }
+  .current-row .pulse { width: 8px; height: 8px; border-radius: 50%; background: var(--cat-amber); flex: none;
+    margin-top: 5px; box-shadow: 0 0 0 4px var(--amber-muted); }
+  .current-row .txt { flex: 1; min-width: 0; }
+  .current-row .txt b { font-size: var(--fs-sm); font-weight: var(--fw-semi); color: var(--text-primary); display: block; }
+  .current-row .txt small { font-size: var(--fs-xs); color: var(--text-tertiary); }
+  .save-btn {
+    display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+    padding: 7px var(--s3); border-radius: var(--r-sm);
+    background: var(--accent); color: var(--on-accent);
+    font-size: var(--fs-sm); font-weight: var(--fw-semi);
+    transition: background var(--t-fast);
+  }
+  .save-btn:hover { background: var(--accent-hover); }
+  .save-btn .icon { width: 14px; height: 14px; }
+
+  .snap-row {
+    display: flex; align-items: center; gap: var(--s3);
+    padding: var(--s3); border-radius: var(--r-md);
+    border: 1px solid transparent;
+    transition: background var(--t-fast), border-color var(--t-fast);
+  }
+  .snap-row:hover { background: var(--bg-hover); border-color: var(--border-subtle); }
+  .snap-dot {
+    width: 26px; height: 26px; border-radius: var(--r-sm); flex: none;
+    display: grid; place-items: center; color: var(--text-tertiary);
+    background: var(--bg-elevated); border: 1px solid var(--border-subtle);
+  }
+  .snap-info { flex: 1; min-width: 0; }
+  .snap-name { font-size: var(--fs-sm); font-weight: var(--fw-medium); color: var(--text-primary);
+    display: flex; align-items: center; gap: var(--s2); }
+  .snap-time { font-size: var(--fs-xs); color: var(--text-tertiary);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .snap-actions { flex: none; }
+  .delta { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px;
+    font-weight: var(--fw-semi); font-family: ui-monospace, "SF Mono", Consolas, monospace; }
+  .delta .up { color: var(--success); } .delta .dn { color: var(--danger); }
+  .snap-actions { display: flex; gap: 2px; }
+  .snap-act {
+    display: grid; place-items: center; width: 26px; height: 26px; border-radius: var(--r-xs);
+    color: var(--text-tertiary);
+    transition: background var(--t-fast), color var(--t-fast);
+  }
+  .snap-act:hover { background: var(--bg-active); color: var(--text-primary); }
+  .snap-act.danger:hover { color: var(--danger); background: var(--danger-muted); }
+
+  /* ============================================================ CANVAS */
+  .canvas {
+    position: relative; min-width: 0; overflow: hidden;
+    background-color: var(--bg-canvas);
+    background-image:
+      linear-gradient(var(--grid-line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid-line) 1px, transparent 1px),
+      linear-gradient(var(--grid-major) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid-major) 1px, transparent 1px);
+    background-size: 26px 26px, 26px 26px, 130px 130px, 130px 130px;
+  }
+  .canvas::after {
+    content: ""; position: absolute; inset: 0; pointer-events: none;
+    background: radial-gradient(120% 90% at 32% 46%, transparent 55%, rgba(0,0,0,.28) 100%);
+  }
+  #app[data-theme="light"] .canvas::after {
+    background: radial-gradient(120% 90% at 32% 46%, transparent 60%, rgba(15,23,42,.05) 100%);
+  }
+
+  .canvas-search {
+    position: absolute; top: var(--s5); left: 50%; transform: translateX(-50%);
+    display: flex; align-items: center; gap: var(--s3);
+    padding: 9px var(--s5); border-radius: var(--r-full);
+    background: color-mix(in srgb, var(--bg-surface) 88%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--border-default);
+    box-shadow: var(--shadow-md);
+    color: var(--text-tertiary); z-index: 6; min-width: 340px;
+  }
+  .canvas-search .icon { width: 16px; height: 16px; }
+  .canvas-search span { font-size: var(--fs-sm); }
+
+  .chart-wrap { position: absolute; inset: 0; display: grid; place-items: center; padding: 88px var(--s7) var(--s8); }
+  .org-svg { width: 100%; height: 100%; }
+
+  /* svg text classes */
+  .svg-name { fill: var(--text-primary); font-size: 13.5px; font-weight: 600; }
+  .svg-title{ fill: var(--text-secondary); font-size: 11px; font-weight: 400; }
+  .svg-lvl  { fill: var(--accent-text); font-size: 9px; font-weight: 600;
+    font-family: ui-monospace, "SF Mono", Consolas, monospace; letter-spacing: .04em; }
+  .card-rect { fill: var(--card-fill); stroke: var(--border-default); stroke-width: 1; }
+  .card-rect.mgr { fill: var(--bg-elevated); }
+  .lvl-badge { fill: var(--accent-muted); }
+  .conn { stroke: var(--border-strong); stroke-width: 1.4; fill: none; }
+  .conn.sel { stroke: var(--accent); stroke-width: 1.8; }
+  .well { fill: var(--bg-well); stroke: var(--border-subtle); stroke-width: 1; }
+  .node { cursor: pointer; }
+  .node .card-rect { transition: stroke .12s, filter .12s; }
+  .node:hover .card-rect { stroke: var(--accent-hover); }
+
+  /* zoom + legend */
+  .canvas-legend, .canvas-zoom {
+    position: absolute; z-index: 6;
+    background: color-mix(in srgb, var(--bg-surface) 90%, transparent);
+    backdrop-filter: blur(8px);
+    border: 1px solid var(--border-default); border-radius: var(--r-md);
+    box-shadow: var(--shadow-sm);
+  }
+  .canvas-legend { right: var(--s5); bottom: var(--s6); padding: var(--s3) var(--s4); }
+  .legend-head { font-size: var(--fs-xs); font-weight: var(--fw-bold); letter-spacing: .07em;
+    text-transform: uppercase; color: var(--text-tertiary); margin-bottom: var(--s2); }
+  .legend-item { display: flex; align-items: center; gap: var(--s2); font-size: var(--fs-sm);
+    color: var(--text-secondary); padding: 2px 0; }
+  .legend-item .sw { width: 9px; height: 9px; border-radius: 50%; }
+  .canvas-zoom { left: var(--s5); bottom: var(--s6); display: flex; align-items: center; padding: 3px; gap: 2px; }
+  .zbtn { display: inline-flex; align-items: center; gap: 5px; padding: 5px var(--s3);
+    border-radius: var(--r-xs); font-size: var(--fs-sm); color: var(--text-secondary);
+    transition: background var(--t-fast), color var(--t-fast); }
+  .zbtn:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .zbtn.val { color: var(--text-tertiary); font-family: ui-monospace, Consolas, monospace; font-size: var(--fs-xs); }
+
+  /* ============================================================ INSPECTOR */
+  .inspector {
+    background: var(--bg-surface);
+    border-left: 1px solid var(--border-subtle);
+    overflow: hidden; min-width: 0;
+    display: flex; flex-direction: column;
+  }
+  .insp-inner { width: var(--inspector-w); display: flex; flex-direction: column; min-height: 0; height: 100%; }
+  .insp-head {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: var(--s4) var(--s5); border-bottom: 1px solid var(--border-subtle);
+  }
+  .insp-head .eyebrow { display: flex; align-items: center; gap: var(--s2); }
+  .insp-head .eyebrow .icon { width: 15px; height: 15px; color: var(--accent-text); }
+  .insp-body { overflow-y: auto; flex: 1; min-height: 0; padding: var(--s5); }
+
+  .identity { display: flex; align-items: flex-start; gap: var(--s3); margin-bottom: var(--s5); }
+  .avatar {
+    width: 44px; height: 44px; border-radius: var(--r-md); flex: none;
+    display: grid; place-items: center; font-weight: var(--fw-bold); font-size: var(--fs-lg);
+    color: var(--accent-text); background: var(--accent-muted);
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
+  }
+  .identity h2 { font-size: var(--fs-xl); font-weight: var(--fw-bold); letter-spacing: -.01em; line-height: 1.15; }
+  .identity .sub { font-size: var(--fs-sm); color: var(--text-secondary); }
+
+  .field { margin-bottom: var(--s4); }
+  .field > label { display: block; font-size: var(--fs-xs); font-weight: var(--fw-semi);
+    letter-spacing: .05em; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 6px; }
+  .input {
+    display: flex; align-items: center; gap: var(--s2);
+    width: 100%; padding: 9px var(--s3); border-radius: var(--r-md);
+    background: var(--bg-base); border: 1px solid var(--border-default);
+    font-size: var(--fs-md); transition: border-color var(--t-fast), box-shadow var(--t-fast);
+  }
+  .input:focus-within, .input.focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+  .input input { flex: 1; background: none; border: none; outline: none; color: var(--text-primary); }
+  .input .ghost { color: var(--text-tertiary); font-size: var(--fs-sm); font-style: italic; white-space: nowrap; }
+  .pin {
+    display: grid; place-items: center; width: 26px; height: 26px; border-radius: var(--r-xs);
+    color: var(--text-tertiary); transition: color var(--t-fast), background var(--t-fast); flex: none;
+  }
+  .pin.active { color: var(--accent-text); background: var(--accent-muted); }
+  .pin:hover { color: var(--accent-text); }
+  .hint { font-size: var(--fs-xs); color: var(--text-tertiary); margin-top: 5px; }
+
+  .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: var(--s3); }
+  .select {
+    display: flex; align-items: center; justify-content: space-between;
+    width: 100%; padding: 9px var(--s3); border-radius: var(--r-md);
+    background: var(--bg-base); border: 1px solid var(--border-default);
+    font-size: var(--fs-md); color: var(--text-primary);
+  }
+  .select .icon { color: var(--text-tertiary); }
+
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 5px var(--s3); border-radius: var(--r-full);
+    font-size: var(--fs-sm); font-weight: var(--fw-medium);
+    border: 1px solid var(--border-default); color: var(--text-secondary);
+    background: var(--bg-base); transition: border-color var(--t-fast), color var(--t-fast);
+  }
+  .chip:hover { border-color: var(--border-strong); color: var(--text-primary); }
+  .chip .sw { width: 8px; height: 8px; border-radius: 50%; }
+  .chip.on { color: var(--text-primary); border-color: var(--accent); background: var(--accent-muted); }
+  .chip.none.on { border-color: var(--border-strong); background: var(--bg-active); }
+
+  .stats {
+    margin: var(--s5) 0;
+    border: 1px solid var(--border-subtle); border-radius: var(--r-lg);
+    background: var(--bg-base); overflow: hidden;
+  }
+  .stat-grid { display: grid; grid-template-columns: 1fr 1fr; }
+  .stat {
+    padding: var(--s3) var(--s4);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .stat:nth-child(odd) { border-right: 1px solid var(--border-subtle); }
+  .stat .k { display: flex; align-items: center; gap: 6px; font-size: var(--fs-xs); color: var(--text-tertiary); }
+  .stat .k .icon { width: 13px; height: 13px; }
+  .stat .v { font-size: var(--fs-xl); font-weight: var(--fw-bold); letter-spacing: -.01em; margin-top: 3px; }
+  .stat .v small { font-size: var(--fs-sm); font-weight: var(--fw-medium); color: var(--text-tertiary); }
+  .reports-to {
+    display: flex; align-items: center; gap: var(--s2);
+    padding: var(--s3) var(--s4); font-size: var(--fs-sm); color: var(--text-secondary);
+  }
+  .reports-to .icon { width: 14px; height: 14px; color: var(--text-tertiary); }
+  .reports-to b { color: var(--text-primary); font-weight: var(--fw-semi); }
+
+  .actions-label { font-size: var(--fs-xs); font-weight: var(--fw-bold); letter-spacing: .07em;
+    text-transform: uppercase; color: var(--text-tertiary); margin-bottom: var(--s3); }
+  .actions { display: grid; grid-template-columns: 1fr 1fr; gap: var(--s2); }
+  .act {
+    display: flex; align-items: center; gap: var(--s2);
+    padding: 9px var(--s3); border-radius: var(--r-md);
+    border: 1px solid var(--border-default); background: var(--bg-base);
+    font-size: var(--fs-sm); font-weight: var(--fw-medium); color: var(--text-secondary);
+    transition: background var(--t-fast), border-color var(--t-fast), color var(--t-fast);
+  }
+  .act:hover { background: var(--bg-hover); color: var(--text-primary); border-color: var(--border-strong); }
+  .act .icon { width: 15px; height: 15px; color: var(--text-tertiary); }
+  .act.primary { grid-column: 1 / -1; justify-content: center;
+    background: var(--accent); color: var(--on-accent); border-color: transparent; font-weight: var(--fw-semi); }
+  .act.primary .icon { color: var(--on-accent); }
+  .act.primary:hover { background: var(--accent-hover); }
+  .act.danger { color: var(--danger); }
+  .act.danger .icon { color: var(--danger); }
+  .act.danger:hover { background: var(--danger-muted); border-color: color-mix(in srgb, var(--danger) 40%, transparent); }
+
+  .insp-caption {
+    display: flex; gap: var(--s2); align-items: flex-start;
+    padding: var(--s3) var(--s4); margin-top: var(--s4);
+    border-radius: var(--r-md); background: var(--bg-base);
+    border: 1px dashed var(--border-default);
+    font-size: var(--fs-xs); color: var(--text-tertiary); line-height: 1.5;
+  }
+  .insp-caption .icon { width: 14px; height: 14px; flex: none; margin-top: 1px; color: var(--text-tertiary); }
+
+  /* ============================================================ FOOTER */
+  .footer {
+    display: flex; align-items: center; gap: var(--s4);
+    padding: 6px var(--s5); border-top: 1px solid var(--border-subtle);
+    background: var(--bg-surface); font-size: var(--fs-xs); color: var(--text-tertiary);
+  }
+  .footer .fdot { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+  .footer .live { color: var(--text-secondary); }
+  .footer .spacer { flex: 1; }
+  .footer .muted-strong { color: var(--text-secondary); font-weight: var(--fw-medium); }
+
+  /* ============================================================ OVERLAYS */
+  .overlay {
+    position: fixed; inset: 0; z-index: 100;
+    display: none; align-items: flex-start; justify-content: center;
+    background: color-mix(in srgb, var(--bg-base) 55%, rgba(0,0,0,.55));
+    backdrop-filter: blur(4px);
+  }
+  .overlay.open { display: flex; animation: fade var(--t); }
+  @keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes rise { from { opacity: 0; transform: translateY(10px) scale(.985); } to { opacity: 1; transform: none; } }
+
+  /* ---- Settings sheet ---- */
+  .settings {
+    margin-top: 5vh; width: min(1000px, 94vw); max-height: 88vh;
+    display: flex; flex-direction: column;
+    background: var(--bg-surface); border: 1px solid var(--border-default);
+    border-radius: var(--r-xl); box-shadow: var(--shadow-lg); overflow: hidden;
+    animation: rise var(--t);
+  }
+  .settings-top {
+    display: flex; align-items: center; gap: var(--s4);
+    padding: var(--s4) var(--s5); border-bottom: 1px solid var(--border-subtle);
+  }
+  .settings-top h1 { font-size: var(--fs-lg); font-weight: var(--fw-bold); display: flex; align-items: center; gap: var(--s3); }
+  .settings-top h1 .icon { color: var(--accent-text); }
+  .settings-search {
+    flex: 1; max-width: 340px; display: flex; align-items: center; gap: var(--s2);
+    padding: 7px var(--s3); border-radius: var(--r-md);
+    background: var(--bg-base); border: 1px solid var(--border-default); color: var(--text-tertiary);
+  }
+  .settings-search .icon { width: 15px; height: 15px; }
+  .settings-search input { flex: 1; background: none; border: none; outline: none; font-size: var(--fs-sm); color: var(--text-primary); }
+  .settings-search .kbd { margin-left: auto; }
+  .settings-close { display: grid; place-items: center; width: 32px; height: 32px; border-radius: var(--r-sm);
+    color: var(--text-secondary); transition: background var(--t-fast), color var(--t-fast); }
+  .settings-close:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+  .preset-strip {
+    display: flex; align-items: center; gap: var(--s3);
+    padding: var(--s3) var(--s5); border-bottom: 1px solid var(--border-subtle);
+    overflow-x: auto;
+  }
+  .preset-strip .plabel { font-size: var(--fs-xs); font-weight: var(--fw-bold); letter-spacing: .06em;
+    text-transform: uppercase; color: var(--text-tertiary); flex: none; }
+  .preset {
+    display: inline-flex; align-items: center; gap: var(--s2); flex: none;
+    padding: 6px var(--s3); border-radius: var(--r-full);
+    border: 1px solid var(--border-default); background: var(--bg-base);
+    font-size: var(--fs-sm); font-weight: var(--fw-medium); color: var(--text-secondary);
+    transition: border-color var(--t-fast), color var(--t-fast);
+  }
+  .preset:hover { border-color: var(--border-strong); color: var(--text-primary); }
+  .preset .sw { width: 13px; height: 13px; border-radius: 4px; border: 1px solid rgba(255,255,255,.15); }
+  .preset.active { border-color: var(--accent); color: var(--text-primary); background: var(--accent-muted); }
+  .preset .tag { font-size: 9px; font-weight: var(--fw-bold); letter-spacing: .05em;
+    color: var(--accent-text); }
+
+  .settings-main { display: grid; grid-template-columns: 196px minmax(0,1fr) 250px; min-height: 0; flex: 1; }
+  .settings-nav { padding: var(--s4) var(--s3); border-right: 1px solid var(--border-subtle); overflow-y: auto; }
+  .settings-nav button {
+    display: flex; align-items: center; gap: var(--s3); width: 100%; text-align: left;
+    padding: 9px var(--s3); border-radius: var(--r-md); margin-bottom: 2px;
+    font-size: var(--fs-md); font-weight: var(--fw-medium); color: var(--text-secondary);
+    transition: background var(--t-fast), color var(--t-fast);
+  }
+  .settings-nav button .icon { width: 16px; height: 16px; color: var(--text-tertiary); }
+  .settings-nav button:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .settings-nav button.active { background: var(--accent-muted); color: var(--text-primary);
+    box-shadow: inset 2px 0 0 var(--accent); }
+  .settings-nav button.active .icon { color: var(--accent-text); }
+
+  .settings-content { padding: var(--s5) var(--s6); overflow-y: auto; }
+  .settings-panel { display: none; }
+  .settings-panel.active { display: block; animation: fade var(--t); }
+  .panel-title { font-size: var(--fs-lg); font-weight: var(--fw-bold); margin-bottom: 3px; }
+  .panel-desc { font-size: var(--fs-sm); color: var(--text-tertiary); margin-bottom: var(--s5); }
+
+  .setting {
+    display: flex; align-items: center; justify-content: space-between; gap: var(--s4);
+    padding: var(--s4) 0; border-bottom: 1px solid var(--border-subtle);
+  }
+  .setting:last-child { border-bottom: none; }
+  .setting .s-label { min-width: 0; }
+  .setting .s-label .name { font-size: var(--fs-md); font-weight: var(--fw-medium); color: var(--text-primary); }
+  .setting .s-label .desc { font-size: var(--fs-xs); color: var(--text-tertiary); margin-top: 2px; }
+  .setting .s-ctrl { flex: none; }
+
+  .seg { display: inline-flex; padding: 3px; border-radius: var(--r-md);
+    background: var(--bg-base); border: 1px solid var(--border-default); }
+  .seg button { padding: 5px var(--s3); border-radius: var(--r-sm); font-size: var(--fs-sm);
+    font-weight: var(--fw-medium); color: var(--text-secondary); }
+  .seg button.on { background: var(--accent); color: var(--on-accent); font-weight: var(--fw-semi); }
+
+  .slider { display: flex; align-items: center; gap: var(--s3); width: 220px; }
+  .track { flex: 1; height: 5px; border-radius: var(--r-full); background: var(--bg-active); position: relative; }
+  .track .fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: var(--r-full); background: var(--accent); }
+  .track .knob { position: absolute; top: 50%; width: 15px; height: 15px; border-radius: 50%;
+    background: var(--bg-surface); border: 2px solid var(--accent); transform: translate(-50%,-50%); box-shadow: var(--shadow-sm); }
+  .sval { font-family: ui-monospace, Consolas, monospace; font-size: var(--fs-sm); color: var(--text-secondary);
+    min-width: 44px; text-align: right; }
+
+  .toggle { width: 40px; height: 23px; border-radius: var(--r-full); background: var(--bg-active);
+    border: 1px solid var(--border-default); position: relative; transition: background var(--t-fast); }
+  .toggle::after { content: ""; position: absolute; top: 2px; left: 2px; width: 17px; height: 17px;
+    border-radius: 50%; background: var(--text-tertiary); transition: transform var(--t-fast), background var(--t-fast); }
+  .toggle.on { background: var(--accent); border-color: transparent; }
+  .toggle.on::after { transform: translateX(17px); background: #fff; }
+
+  .selbox { padding: 7px var(--s3); border-radius: var(--r-md); background: var(--bg-base);
+    border: 1px solid var(--border-default); font-size: var(--fs-sm); color: var(--text-primary);
+    display: inline-flex; align-items: center; gap: var(--s3); }
+  .selbox .icon { color: var(--text-tertiary); width: 15px; height: 15px; }
+
+  /* levels table */
+  .lvl-table { border: 1px solid var(--border-subtle); border-radius: var(--r-md); overflow: hidden; }
+  .lvl-line { display: grid; grid-template-columns: 70px 1fr auto; align-items: center; gap: var(--s3);
+    padding: 9px var(--s4); border-bottom: 1px solid var(--border-subtle); font-size: var(--fs-sm); }
+  .lvl-line:last-child { border-bottom: none; }
+  .lvl-line .code { font-family: ui-monospace, Consolas, monospace; font-weight: var(--fw-semi); color: var(--accent-text); }
+  .lvl-line .map { color: var(--text-primary); }
+  .lvl-line .badge-prev { font-size: 10px; font-family: ui-monospace, Consolas, monospace;
+    padding: 2px 7px; border-radius: var(--r-xs); background: var(--accent-muted); color: var(--accent-text); }
+  .cat-line { display: flex; align-items: center; gap: var(--s3); padding: 9px 0; }
+  .cat-line .sw { width: 14px; height: 14px; border-radius: 4px; }
+  .cat-line .cn { font-size: var(--fs-md); font-weight: var(--fw-medium); flex: 1; }
+  .cat-line .hex { font-family: ui-monospace, Consolas, monospace; font-size: var(--fs-xs); color: var(--text-tertiary); }
+
+  /* live preview pane */
+  .settings-preview {
+    border-left: 1px solid var(--border-subtle); background: var(--bg-canvas);
+    padding: var(--s5) var(--s4); overflow-y: auto;
+    background-image:
+      linear-gradient(var(--grid-line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid-line) 1px, transparent 1px);
+    background-size: 20px 20px;
+  }
+  .preview-head { font-size: var(--fs-xs); font-weight: var(--fw-bold); letter-spacing: .07em;
+    text-transform: uppercase; color: var(--text-tertiary); margin-bottom: var(--s4);
+    display: flex; align-items: center; justify-content: space-between; }
+  .preview-head .live-dot { display: inline-flex; align-items: center; gap: 5px; color: var(--accent-text);
+    font-size: 10px; letter-spacing: .02em; }
+  .preview-head .live-dot .d { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+  .mini-cards { display: flex; flex-direction: column; align-items: center; gap: var(--s2); }
+  .mini-card {
+    width: 168px; padding: var(--s3); border-radius: var(--r-md);
+    background: var(--card-fill); border: 1px solid var(--border-default);
+    box-shadow: var(--shadow-sm); position: relative;
+  }
+  .mini-card.sel { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+  .mini-card .mn { font-size: var(--fs-sm); font-weight: var(--fw-semi); }
+  .mini-card .mt { font-size: var(--fs-xs); color: var(--text-secondary); }
+  .mini-card .mb { position: absolute; top: 10px; right: 10px; font-size: 8.5px; font-family: ui-monospace, Consolas, monospace;
+    color: var(--accent-text); background: var(--accent-muted); padding: 1px 5px; border-radius: 4px; }
+  .mini-conn { width: 1.4px; height: 16px; background: var(--border-strong); }
+
+  .settings-foot {
+    display: flex; align-items: center; gap: var(--s4);
+    padding: var(--s4) var(--s5); border-top: 1px solid var(--border-subtle);
+  }
+  .settings-foot .foot-note { font-size: var(--fs-xs); color: var(--text-tertiary); flex: 1; }
+  .btn { padding: 9px var(--s5); border-radius: var(--r-md); font-size: var(--fs-md);
+    font-weight: var(--fw-semi); transition: background var(--t-fast), border-color var(--t-fast); }
+  .btn.ghost { border: 1px solid var(--border-default); color: var(--text-secondary); }
+  .btn.ghost:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .btn.primary { background: var(--accent); color: var(--on-accent); }
+  .btn.primary:hover { background: var(--accent-hover); }
+
+  /* ---- Command palette ---- */
+  .palette {
+    margin-top: 12vh; width: min(620px, 92vw);
+    background: var(--bg-surface); border: 1px solid var(--border-default);
+    border-radius: var(--r-lg); box-shadow: var(--shadow-lg); overflow: hidden;
+    animation: rise var(--t);
+  }
+  .palette-input {
+    display: flex; align-items: center; gap: var(--s3);
+    padding: var(--s4) var(--s5); border-bottom: 1px solid var(--border-subtle);
+  }
+  .palette-input .icon { width: 19px; height: 19px; color: var(--text-tertiary); }
+  .palette-input input { flex: 1; background: none; border: none; outline: none;
+    font-size: var(--fs-lg); color: var(--text-primary); }
+  .palette-input input::placeholder { color: var(--text-tertiary); }
+  .palette-input .esc { font-size: var(--fs-xs); color: var(--text-tertiary); }
+  .palette-body { max-height: 400px; overflow-y: auto; padding: var(--s2); }
+  .pal-group { font-size: var(--fs-xs); font-weight: var(--fw-bold); letter-spacing: .07em;
+    text-transform: uppercase; color: var(--text-tertiary); padding: var(--s3) var(--s3) var(--s2); }
+  .pal-item {
+    display: flex; align-items: center; gap: var(--s3);
+    padding: 9px var(--s3); border-radius: var(--r-md); width: 100%; text-align: left;
+    color: var(--text-secondary); transition: background var(--t-fast), color var(--t-fast);
+  }
+  .pal-item:hover, .pal-item.active { background: var(--bg-hover); color: var(--text-primary); }
+  .pal-item .pic { display: grid; place-items: center; width: 30px; height: 30px; border-radius: var(--r-sm);
+    background: var(--bg-elevated); border: 1px solid var(--border-subtle); color: var(--accent-text); flex: none; }
+  .pal-item .pic .icon { width: 15px; height: 15px; }
+  .pal-item .plabel { flex: 1; font-size: var(--fs-md); font-weight: var(--fw-medium); color: inherit; }
+  .pal-item .psub { font-size: var(--fs-xs); color: var(--text-tertiary); }
+  .pal-item .keys { display: flex; gap: 3px; }
+  .palette.active .pal-item.active { background: var(--accent-muted); box-shadow: inset 2px 0 0 var(--accent); }
+
+  /* ============================================================ RESPONSIVE */
+  @media (max-width: 1300px) {
+    #app { --sidebar-w: 236px; --inspector-w: 312px; }
+  }
+  @media (max-width: 1080px) {
+    #app { --sidebar-w: 216px; --inspector-w: 296px; }
+    .canvas-search { min-width: 260px; }
+    .footer .hide-sm { display: none; }
+    .settings-main { grid-template-columns: 176px minmax(0,1fr); }
+    .settings-preview { display: none; }
+  }
+  @media (max-width: 900px) {
+    .header-center { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ===================== ICON SPRITE ===================== -->
+<svg style="display:none" aria-hidden="true"><defs>
+  <symbol id="i-leaf" viewBox="0 0 24 24"><path d="M11 20A7 7 0 0 1 9.8 6.1C15.5 5 17 4.5 19 2c1 2 2 4.5 2 8.5A7.5 7.5 0 0 1 11 20z"/><path d="M2 21c0-3 1.85-6.5 5-8"/></symbol>
+  <symbol id="i-plus" viewBox="0 0 24 24"><path d="M5 12h14M12 5v14"/></symbol>
+  <symbol id="i-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></symbol>
+  <symbol id="i-sliders" viewBox="0 0 24 24"><path d="M4 6h9M17 6h3M4 12h3M11 12h9M4 18h13M20 18h0M17 18h.01"/><circle cx="15" cy="6" r="2"/><circle cx="9" cy="12" r="2"/><circle cx="15" cy="18" r="2"/></symbol>
+  <symbol id="i-download" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3"/></symbol>
+  <symbol id="i-upload" viewBox="0 0 24 24"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></symbol>
+  <symbol id="i-bar" viewBox="0 0 24 24"><path d="M3 3v18h18M7 15v3M12 9v9M17 5v13"/></symbol>
+  <symbol id="i-help" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.1 9a3 3 0 0 1 5.8 1c0 2-3 2.5-3 4"/><path d="M12 17h.01"/></symbol>
+  <symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4"/></symbol>
+  <symbol id="i-moon" viewBox="0 0 24 24"><path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z"/></symbol>
+  <symbol id="i-x" viewBox="0 0 24 24"><path d="M18 6 6 18M6 6l12 12"/></symbol>
+  <symbol id="i-pin" viewBox="0 0 24 24"><path d="M12 17v5M9 10.8V6a1 1 0 0 1 1-1 2 2 0 0 0 0-4H14a2 2 0 0 0 0 4 1 1 0 0 1 1 1v4.8a2 2 0 0 0 1.1 1.8l1 .5A2 2 0 0 1 18 14.6V16H6v-1.4a2 2 0 0 1 1-1.7l1-.5a2 2 0 0 0 1-1.6z"/></symbol>
+  <symbol id="i-users" viewBox="0 0 24 24"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.9M16 3.1a4 4 0 0 1 0 7.8"/></symbol>
+  <symbol id="i-network" viewBox="0 0 24 24"><rect x="9" y="3" width="6" height="6" rx="1"/><rect x="3" y="15" width="6" height="6" rx="1"/><rect x="15" y="15" width="6" height="6" rx="1"/><path d="M12 9v3M12 12H6v3M12 12h6v3"/></symbol>
+  <symbol id="i-span" viewBox="0 0 24 24"><path d="M6 8l-4 4 4 4M18 8l4 4-4 4M2 12h20"/></symbol>
+  <symbol id="i-chev-down" viewBox="0 0 24 24"><path d="m6 9 6 6 6-6"/></symbol>
+  <symbol id="i-chev-right" viewBox="0 0 24 24"><path d="m9 6 6 6-6 6"/></symbol>
+  <symbol id="i-eye" viewBox="0 0 24 24"><path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z"/><circle cx="12" cy="12" r="3"/></symbol>
+  <symbol id="i-compare" viewBox="0 0 24 24"><circle cx="5" cy="6" r="3"/><circle cx="19" cy="18" r="3"/><path d="M12 6h4a2 2 0 0 1 2 2v7M12 18H8a2 2 0 0 1-2-2V9"/></symbol>
+  <symbol id="i-restore" viewBox="0 0 24 24"><path d="M3 3v6h6"/><path d="M3.5 9a9 9 0 1 0 2.2-3.4L3 8"/></symbol>
+  <symbol id="i-save" viewBox="0 0 24 24"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><path d="M17 21v-8H7v8M7 3v5h8"/></symbol>
+  <symbol id="i-command" viewBox="0 0 24 24"><path d="M15 6a3 3 0 1 1 3 3h-3zM15 9v6M9 6a3 3 0 1 0-3 3h3zM9 9v6M9 15a3 3 0 1 0 3 3v-3zM15 15h-3M15 15a3 3 0 1 1 3 3v-3zM9 9h6"/></symbol>
+  <symbol id="i-enter" viewBox="0 0 24 24"><path d="M9 10 4 15l5 5"/><path d="M20 4v7a4 4 0 0 1-4 4H4"/></symbol>
+  <symbol id="i-move" viewBox="0 0 24 24"><path d="M5 9l-3 3 3 3M9 5l3-3 3 3M15 19l-3 3-3-3M19 9l3 3-3 3M2 12h20M12 2v20"/></symbol>
+  <symbol id="i-focus" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="3"/><path d="M12 3v3M12 18v3M3 12h3M18 12h3"/></symbol>
+  <symbol id="i-link" viewBox="0 0 24 24"><path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.7 1.7"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7l1.7-1.7"/></symbol>
+  <symbol id="i-trash" viewBox="0 0 24 24"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M10 11v6M14 11v6"/></symbol>
+  <symbol id="i-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></symbol>
+  <symbol id="i-up" viewBox="0 0 24 24"><path d="M12 19V5M5 12l7-7 7 7"/></symbol>
+  <symbol id="i-down" viewBox="0 0 24 24"><path d="M12 5v14M19 12l-7 7-7-7"/></symbol>
+  <symbol id="i-palette" viewBox="0 0 24 24"><path d="M12 2a10 10 0 1 0 0 20c1.1 0 2-.9 2-2 0-.5-.2-1-.5-1.3-.3-.4-.5-.8-.5-1.2 0-1.1.9-2 2-2H17a5 5 0 0 0 5-5c0-5-4.5-8.5-10-8.5z"/><circle cx="7.5" cy="10.5" r="1.2"/><circle cx="12" cy="7.5" r="1.2"/><circle cx="16.5" cy="10.5" r="1.2"/></symbol>
+  <symbol id="i-layout" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></symbol>
+  <symbol id="i-card" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 10h18M7 15h5"/></symbol>
+  <symbol id="i-layers" viewBox="0 0 24 24"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="M2 12l10 5 10-5M2 17l10 5 10-5"/></symbol>
+  <symbol id="i-database" viewBox="0 0 24 24"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0 0 18 0V5M3 12a9 3 0 0 0 18 0"/></symbol>
+  <symbol id="i-type" viewBox="0 0 24 24"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></symbol>
+  <symbol id="i-tree" viewBox="0 0 24 24"><rect x="9" y="3" width="6" height="5" rx="1"/><rect x="3" y="16" width="6" height="5" rx="1"/><rect x="15" y="16" width="6" height="5" rx="1"/><path d="M12 8v4M6 16v-2h12v2"/></symbol>
+  <symbol id="i-check" viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></symbol>
+  <symbol id="i-info" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 11v5M12 8h.01"/></symbol>
+  <symbol id="i-fit" viewBox="0 0 24 24"><path d="M3 8V5a2 2 0 0 1 2-2h3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M21 16v3a2 2 0 0 1-2 2h-3"/></symbol>
+  <symbol id="i-pencil" viewBox="0 0 24 24"><path d="M12 20h9M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></symbol>
+  <symbol id="i-undo" viewBox="0 0 24 24"><path d="M3 7v6h6"/><path d="M3.5 13a9 9 0 1 1 2 6"/></symbol>
+  <symbol id="i-redo" viewBox="0 0 24 24"><path d="M21 7v6h-6"/><path d="M20.5 13a9 9 0 1 0-2 6"/></symbol>
+</defs></svg>
+
+<!-- ===================== APP ===================== -->
+<div id="app" data-theme="dark">
+
+  <!-- HEADER -->
+  <header class="header">
+    <div class="brand">
+      <span class="brand-leaf"><svg class="icon"><use href="#i-leaf"/></svg></span>
+      <span class="wordmark"><b>Ar</b><span>bol</span></span>
+    </div>
+
+    <div class="header-center">
+      <div class="chart-name">
+        <span class="title">Acme Corp <svg class="icon icon-sm"><use href="#i-pencil"/></svg></span>
+        <span class="pill unsaved"><span class="dot"></span>Saved · 3 edits since last version</span>
+      </div>
+      <button class="cmdk" id="palette-btn" aria-label="Open command palette">
+        <svg class="icon"><use href="#i-command"/></svg>
+        Search &amp; commands
+        <span class="kbd">⌘K</span>
+      </button>
+    </div>
+
+    <div class="header-actions">
+      <button class="hbtn icon-btn-label" data-label="Undo" aria-label="Undo"><svg class="icon"><use href="#i-undo"/></svg></button>
+      <button class="hbtn icon-btn-label" data-label="Redo" aria-label="Redo"><svg class="icon"><use href="#i-redo"/></svg></button>
+      <span class="hdiv"></span>
+      <button class="hbtn icon-btn-label" data-label="Import" aria-label="Import"><svg class="icon"><use href="#i-download"/></svg></button>
+      <button class="hbtn icon-btn-label" data-label="Export" aria-label="Export"><svg class="icon"><use href="#i-upload"/></svg></button>
+      <button class="hbtn icon-btn-label" data-label="Analytics" aria-label="Analytics"><svg class="icon"><use href="#i-bar"/></svg></button>
+      <span class="hdiv"></span>
+      <button class="hbtn icon-btn-label" data-label="Settings" id="settings-btn" aria-label="Settings"><svg class="icon"><use href="#i-sliders"/></svg></button>
+      <button class="hbtn icon-btn-label" data-label="Help" aria-label="Help"><svg class="icon"><use href="#i-help"/></svg></button>
+      <button class="hbtn icon-btn-label" data-label="Theme" id="theme-toggle" aria-label="Toggle theme">
+        <svg class="icon theme-icon-sun"><use href="#i-sun"/></svg>
+        <svg class="icon theme-icon-moon"><use href="#i-moon"/></svg>
+      </button>
+    </div>
+  </header>
+
+  <!-- MAIN -->
+  <div class="main">
+
+    <!-- SIDEBAR -->
+    <aside class="sidebar">
+      <div class="side-scroll">
+        <div class="side-section">
+          <div class="side-head">
+            <span class="eyebrow">Charts</span>
+            <button class="icon-mini" aria-label="New chart"><svg class="icon icon-sm"><use href="#i-plus"/></svg></button>
+          </div>
+          <div class="search-field">
+            <svg class="icon"><use href="#i-search"/></svg>
+            <input placeholder="Search charts…" aria-label="Search charts">
+          </div>
+          <button class="chart-row active">
+            <span class="chart-ic"><svg class="icon"><use href="#i-tree"/></svg></span>
+            <span class="chart-meta">
+              <span class="chart-title">Acme Corp</span>
+              <span class="chart-sub">13 people · 2 versions</span>
+            </span>
+          </button>
+          <button class="chart-row">
+            <span class="chart-ic"><svg class="icon"><use href="#i-tree"/></svg></span>
+            <span class="chart-meta">
+              <span class="chart-title">Product Reorg (draft)</span>
+              <span class="chart-sub">9 people · 0 versions</span>
+            </span>
+          </button>
+        </div>
+
+        <div class="divider"></div>
+
+        <div class="snap-section">
+          <div class="side-head">
+            <span class="eyebrow">Version history</span>
+            <span class="eyebrow" style="text-transform:none;letter-spacing:0;font-weight:500;color:var(--text-tertiary)">Acme Corp</span>
+          </div>
+
+          <div class="current-row">
+            <div class="cr-head">
+              <span class="pulse"></span>
+              <span class="txt">
+                <b>Current — all changes saved</b>
+                <small>3 edits since last version</small>
+              </span>
+            </div>
+            <button class="save-btn"><svg class="icon"><use href="#i-save"/></svg>Save a version</button>
+          </div>
+
+          <div class="snap-row">
+            <span class="snap-dot"><svg class="icon icon-sm"><use href="#i-clock"/></svg></span>
+            <span class="snap-info">
+              <span class="snap-name">Q3 Baseline
+                <span class="delta"><span class="up">▲3</span><span class="dn">▼1</span></span>
+              </span>
+              <span class="snap-time">3 days ago · 11 people</span>
+            </span>
+            <span class="snap-actions">
+              <button class="snap-act" aria-label="Preview version"><svg class="icon icon-sm"><use href="#i-eye"/></svg></button>
+              <button class="snap-act" aria-label="Compare version"><svg class="icon icon-sm"><use href="#i-compare"/></svg></button>
+              <button class="snap-act" aria-label="Restore version"><svg class="icon icon-sm"><use href="#i-restore"/></svg></button>
+            </span>
+          </div>
+
+          <div class="snap-row">
+            <span class="snap-dot"><svg class="icon icon-sm"><use href="#i-clock"/></svg></span>
+            <span class="snap-info">
+              <span class="snap-name">Initial import
+                <span class="delta"><span class="up">▲8</span></span>
+              </span>
+              <span class="snap-time">Jul 2 · 8 people</span>
+            </span>
+            <span class="snap-actions">
+              <button class="snap-act" aria-label="Preview version"><svg class="icon icon-sm"><use href="#i-eye"/></svg></button>
+              <button class="snap-act" aria-label="Compare version"><svg class="icon icon-sm"><use href="#i-compare"/></svg></button>
+              <button class="snap-act" aria-label="Restore version"><svg class="icon icon-sm"><use href="#i-restore"/></svg></button>
+            </span>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- CANVAS -->
+    <section class="canvas">
+      <div class="canvas-search">
+        <svg class="icon"><use href="#i-search"/></svg>
+        <span>Search by name or title…</span>
+        <span class="kbd" style="margin-left:auto">Ctrl F</span>
+      </div>
+
+      <div class="chart-wrap">
+        <svg class="org-svg" viewBox="0 0 1800 630" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Acme Corp org chart, 13 people. Marcus Johnson selected.">
+          <defs>
+            <radialGradient id="subtreeGlow" cx="50%" cy="50%" r="50%">
+              <stop offset="0%"  stop-color="var(--accent)" stop-opacity="0.22"/>
+              <stop offset="45%" stop-color="var(--accent)" stop-opacity="0.09"/>
+              <stop offset="100%" stop-color="var(--accent)" stop-opacity="0"/>
+            </radialGradient>
+            <filter id="nodeGlow" x="-40%" y="-60%" width="180%" height="220%">
+              <feDropShadow dx="0" dy="0" stdDeviation="9" flood-color="var(--accent)" flood-opacity="0.55"/>
+            </filter>
+          </defs>
+
+          <!-- selection lens glow under Marcus subtree -->
+          <ellipse cx="534" cy="405" rx="565" ry="270" fill="url(#subtreeGlow)"/>
+
+          <!-- subtle IC wells (not gray slabs) -->
+          <rect class="well" x="20"   y="516" width="410" height="98" rx="14"/>
+          <rect class="well" x="440"  y="516" width="608" height="98" rx="14"/>
+          <rect class="well" x="1160" y="346" width="608" height="98" rx="14"/>
+
+          <!-- connectors -->
+          <g>
+            <!-- Sarah -> VPs -->
+            <path class="conn" d="M974 86 V143"/>
+            <path class="conn" d="M484 143 H1464"/>
+            <path class="conn sel" d="M484 143 V200"/>
+            <path class="conn" d="M1464 143 V200"/>
+            <!-- Marcus -> David / Lisa (selected subtree) -->
+            <path class="conn sel" d="M484 256 V313"/>
+            <path class="conn sel" d="M224 313 H744"/>
+            <path class="conn sel" d="M224 313 V370"/>
+            <path class="conn sel" d="M744 313 V370"/>
+            <!-- Priya -> ICs -->
+            <path class="conn" d="M1464 256 V313"/>
+            <path class="conn" d="M1264 313 H1664"/>
+            <path class="conn" d="M1264 313 V370"/>
+            <path class="conn" d="M1464 313 V370"/>
+            <path class="conn" d="M1664 313 V370"/>
+            <!-- David -> Tom / Ana -->
+            <path class="conn sel" d="M224 426 V483"/>
+            <path class="conn sel" d="M124 483 H324"/>
+            <path class="conn sel" d="M124 483 V540"/>
+            <path class="conn sel" d="M324 483 V540"/>
+            <!-- Lisa -> James / Emma / Raj -->
+            <path class="conn sel" d="M744 426 V483"/>
+            <path class="conn sel" d="M544 483 H944"/>
+            <path class="conn sel" d="M544 483 V540"/>
+            <path class="conn sel" d="M744 483 V540"/>
+            <path class="conn sel" d="M944 483 V540"/>
+          </g>
+
+          <!-- ===== NODES ===== -->
+          <!-- Sarah Chen (CEO) -->
+          <g class="node" transform="translate(886,30)">
+            <rect class="card-rect mgr" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Sarah Chen</text>
+            <text class="svg-title" x="16" y="42">Chief Executive Officer</text>
+            <rect class="lvl-badge" x="128" y="9" width="34" height="15" rx="4"/>
+            <text class="svg-lvl" x="145" y="19.5" text-anchor="middle">E12</text>
+          </g>
+
+          <!-- Marcus Johnson (VP Eng) — SELECTED -->
+          <g class="node" id="node-marcus" transform="translate(396,200)" tabindex="0" role="button" aria-label="Marcus Johnson, VP Engineering, selected">
+            <rect class="card-rect mgr" width="176" height="56" rx="12" filter="url(#nodeGlow)" stroke="var(--accent)" stroke-width="2"/>
+            <text class="svg-name" x="16" y="26">Marcus Johnson</text>
+            <text class="svg-title" x="16" y="42">VP Engineering</text>
+            <rect class="lvl-badge" x="128" y="9" width="34" height="15" rx="4"/>
+            <text class="svg-lvl" x="145" y="19.5" text-anchor="middle">E10</text>
+          </g>
+
+          <!-- Priya Patel (VP Product) -->
+          <g class="node" transform="translate(1376,200)">
+            <rect class="card-rect mgr" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Priya Patel</text>
+            <text class="svg-title" x="16" y="42">VP Product</text>
+            <rect class="lvl-badge" x="128" y="9" width="34" height="15" rx="4"/>
+            <text class="svg-lvl" x="145" y="19.5" text-anchor="middle">E10</text>
+          </g>
+
+          <!-- David Kim -->
+          <g class="node" transform="translate(136,370)">
+            <rect class="card-rect mgr" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">David Kim</text>
+            <text class="svg-title" x="16" y="42">Senior Engineering Manager</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">E8</text>
+          </g>
+
+          <!-- Lisa Wang -->
+          <g class="node" transform="translate(656,370)">
+            <rect class="card-rect mgr" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Lisa Wang</text>
+            <text class="svg-title" x="16" y="42">Engineering Manager</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">E8</text>
+          </g>
+
+          <!-- Nina Petrov -->
+          <g class="node" transform="translate(1176,370)">
+            <rect class="card-rect mgr" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Nina Petrov</text>
+            <text class="svg-title" x="16" y="42">Senior Product Manager</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">E8</text>
+          </g>
+
+          <!-- Carlos Ruiz -->
+          <g class="node" transform="translate(1376,370)">
+            <rect class="card-rect" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Carlos Ruiz</text>
+            <text class="svg-title" x="16" y="42">Product Manager</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L6</text>
+          </g>
+
+          <!-- Yuki Tanaka — Offer Pending (blue) -->
+          <g class="node" transform="translate(1576,370)">
+            <rect class="card-rect" width="176" height="56" rx="12" stroke="var(--cat-blue)"/>
+            <rect x="6" y="12" width="4" height="32" rx="2" fill="var(--cat-blue)"/>
+            <text class="svg-name" x="18" y="26">Yuki Tanaka</text>
+            <text class="svg-title" x="18" y="42">Product Designer</text>
+            <circle cx="120" cy="16.5" r="4" fill="var(--cat-blue)"/>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L6</text>
+          </g>
+
+          <!-- Tom Rodriguez -->
+          <g class="node" transform="translate(36,540)">
+            <rect class="card-rect" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Tom Rodriguez</text>
+            <text class="svg-title" x="16" y="42">Staff Engineer</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L7</text>
+          </g>
+
+          <!-- Ana Costa -->
+          <g class="node" transform="translate(236,540)">
+            <rect class="card-rect" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Ana Costa</text>
+            <text class="svg-title" x="16" y="42">Senior Engineer</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L6</text>
+          </g>
+
+          <!-- James Miller -->
+          <g class="node" transform="translate(456,540)">
+            <rect class="card-rect" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">James Miller</text>
+            <text class="svg-title" x="16" y="42">Senior Engineer</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L6</text>
+          </g>
+
+          <!-- Emma Wilson -->
+          <g class="node" transform="translate(656,540)">
+            <rect class="card-rect" width="176" height="56" rx="12"/>
+            <text class="svg-name" x="16" y="26">Emma Wilson</text>
+            <text class="svg-title" x="16" y="42">Engineer</text>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L5</text>
+          </g>
+
+          <!-- Raj Sharma — Open Position (amber) -->
+          <g class="node" transform="translate(856,540)">
+            <rect class="card-rect" width="176" height="56" rx="12" stroke="var(--cat-amber)"/>
+            <rect x="6" y="12" width="4" height="32" rx="2" fill="var(--cat-amber)"/>
+            <text class="svg-name" x="18" y="26">Raj Sharma</text>
+            <text class="svg-title" x="18" y="42">Engineer</text>
+            <circle cx="120" cy="16.5" r="4" fill="var(--cat-amber)"/>
+            <rect class="lvl-badge" x="140" y="9" width="26" height="15" rx="4"/>
+            <text class="svg-lvl" x="153" y="19.5" text-anchor="middle">L5</text>
+          </g>
+        </svg>
+      </div>
+
+      <div class="canvas-legend">
+        <div class="legend-head">Categories</div>
+        <div class="legend-item"><span class="sw" style="background:var(--cat-amber)"></span>Open Position</div>
+        <div class="legend-item"><span class="sw" style="background:var(--cat-blue)"></span>Offer Pending</div>
+        <div class="legend-item"><span class="sw" style="background:var(--cat-violet)"></span>Future Start</div>
+      </div>
+
+      <div class="canvas-zoom">
+        <button class="zbtn"><svg class="icon icon-sm"><use href="#i-fit"/></svg>Fit</button>
+        <button class="zbtn"><svg class="icon icon-sm"><use href="#i-restore"/></svg>Reset</button>
+        <span class="zbtn val">100%</span>
+      </div>
+    </section>
+
+    <!-- INSPECTOR -->
+    <aside class="inspector">
+      <div class="insp-inner">
+        <div class="insp-head">
+          <span class="eyebrow"><svg class="icon"><use href="#i-sliders"/></svg> Inspector</span>
+          <button class="icon-mini" id="inspector-close" aria-label="Close inspector"><svg class="icon icon-sm"><use href="#i-x"/></svg></button>
+        </div>
+
+        <div class="insp-body">
+          <div class="identity">
+            <span class="avatar">MJ</span>
+            <div>
+              <h2>Marcus Johnson</h2>
+              <div class="sub">VP Engineering · reports to Sarah Chen</div>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Name</label>
+            <div class="input focus"><input value="Marcus Johnson" aria-label="Name"></div>
+          </div>
+
+          <div class="field">
+            <label>Title</label>
+            <div class="input">
+              <input value="VP Engineering" aria-label="Title">
+              <span class="ghost">Vice President</span>
+              <button class="pin active" aria-label="Pin mapped title" title="Title pinned to level mapping"><svg class="icon icon-sm"><use href="#i-pin"/></svg></button>
+            </div>
+            <div class="hint">Ghost text is the mapped title for level E10. Unpin to override.</div>
+          </div>
+
+          <div class="row2">
+            <div class="field">
+              <label>Level</label>
+              <div class="select"><span>E10</span><svg class="icon icon-sm"><use href="#i-chev-down"/></svg></div>
+            </div>
+            <div class="field">
+              <label>Reports to</label>
+              <div class="select"><span>Sarah Chen</span><svg class="icon icon-sm"><use href="#i-chev-down"/></svg></div>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Category</label>
+            <div class="chips">
+              <button class="chip none on">None</button>
+              <button class="chip"><span class="sw" style="background:var(--cat-amber)"></span>Open Position</button>
+              <button class="chip"><span class="sw" style="background:var(--cat-blue)"></span>Offer Pending</button>
+              <button class="chip"><span class="sw" style="background:var(--cat-violet)"></span>Future Start</button>
+            </div>
+          </div>
+
+          <div class="stats">
+            <div class="stat-grid">
+              <div class="stat">
+                <div class="k"><svg class="icon"><use href="#i-users"/></svg>Direct reports</div>
+                <div class="v">2</div>
+              </div>
+              <div class="stat">
+                <div class="k"><svg class="icon"><use href="#i-network"/></svg>Total org</div>
+                <div class="v">7</div>
+              </div>
+              <div class="stat">
+                <div class="k"><svg class="icon"><use href="#i-span"/></svg>Avg span</div>
+                <div class="v">2.3</div>
+              </div>
+              <div class="stat">
+                <div class="k"><svg class="icon"><use href="#i-layers"/></svg>Depth below</div>
+                <div class="v">2 <small>levels</small></div>
+              </div>
+            </div>
+            <div class="reports-to">
+              <svg class="icon"><use href="#i-pin"/></svg> Reports to <b>Sarah Chen</b> · E12
+            </div>
+          </div>
+
+          <div class="actions-label">Actions</div>
+          <div class="actions">
+            <button class="act primary"><svg class="icon"><use href="#i-plus"/></svg>Add report</button>
+            <button class="act"><svg class="icon"><use href="#i-move"/></svg>Move</button>
+            <button class="act"><svg class="icon"><use href="#i-focus"/></svg>Focus</button>
+            <button class="act"><svg class="icon"><use href="#i-link"/></svg>Dotted line</button>
+            <button class="act danger"><svg class="icon"><use href="#i-trash"/></svg>Remove</button>
+          </div>
+
+          <div class="insp-caption">
+            <svg class="icon"><use href="#i-info"/></svg>
+            <span>Right-clicking a node opens the same actions as shortcuts into this panel — one edit surface, no separate dialogs.</span>
+          </div>
+        </div>
+      </div>
+    </aside>
+  </div>
+
+  <!-- FOOTER -->
+  <footer class="footer">
+    <span class="fdot"></span>
+    <span class="live">Static mock — theme, command palette, inspector &amp; settings sheet are live.</span>
+    <span class="hide-sm">Chart editing, drag &amp; export are illustrative.</span>
+    <span class="spacer"></span>
+    <span class="hide-sm muted-strong">Arbol v4.0</span>
+    <span class="hide-sm">·</span>
+    <span class="hide-sm">Acme Corp · 13 people · 4 managers · 9 ICs</span>
+  </footer>
+
+  <!-- ===================== SETTINGS SHEET ===================== -->
+  <div class="overlay" id="settings-overlay" role="dialog" aria-modal="true" aria-label="Settings">
+    <div class="settings">
+      <div class="settings-top">
+        <h1><svg class="icon"><use href="#i-sliders"/></svg> Settings</h1>
+        <div class="settings-search">
+          <svg class="icon"><use href="#i-search"/></svg>
+          <input placeholder="Search all settings…" aria-label="Search settings">
+          <span class="kbd">/</span>
+        </div>
+        <button class="settings-close" id="settings-close" aria-label="Close settings"><svg class="icon"><use href="#i-x"/></svg></button>
+      </div>
+
+      <div class="preset-strip">
+        <span class="plabel">Preset</span>
+        <button class="preset active"><span class="sw" style="background:#14b8a6"></span>Emerald <span class="tag">ACTIVE</span></button>
+        <button class="preset"><span class="sw" style="background:#3b82f6"></span>Corporate Blue</button>
+        <button class="preset"><span class="sw" style="background:#f59e0b"></span>Sunset Warm</button>
+        <button class="preset"><span class="sw" style="background:#1e293b"></span>Midnight</button>
+        <button class="preset"><span class="sw" style="background:#64748b"></span>Monochrome</button>
+        <button class="preset"><span class="sw" style="background:#0ea5e9"></span>Ocean Teal</button>
+        <button class="preset"><span class="sw" style="background:#111827"></span>High Contrast</button>
+      </div>
+
+      <div class="settings-main">
+        <!-- group nav -->
+        <nav class="settings-nav" role="tablist">
+          <button data-group="appearance"><svg class="icon"><use href="#i-palette"/></svg>Appearance</button>
+          <button data-group="layout"><svg class="icon"><use href="#i-layout"/></svg>Layout</button>
+          <button class="active" data-group="cards"><svg class="icon"><use href="#i-card"/></svg>Cards &amp; Badges</button>
+          <button data-group="levels"><svg class="icon"><use href="#i-layers"/></svg>Levels &amp; Categories</button>
+          <button data-group="presets"><svg class="icon"><use href="#i-palette"/></svg>Presets</button>
+          <button data-group="data"><svg class="icon"><use href="#i-database"/></svg>Data &amp; Backup</button>
+        </nav>
+
+        <!-- content -->
+        <div class="settings-content">
+          <!-- APPEARANCE -->
+          <div class="settings-panel" data-panel="appearance">
+            <div class="panel-title">Appearance</div>
+            <div class="panel-desc">Theme, accent color and canvas texture for the editor.</div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Theme</div><div class="desc">Editor color scheme. Exports always render light.</div></div>
+              <div class="s-ctrl"><div class="seg"><button>Light</button><button class="on">Dark</button><button>System</button></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Font family</div><div class="desc">Applied to node cards and chrome.</div></div>
+              <div class="s-ctrl"><div class="selbox"><svg class="icon"><use href="#i-type"/></svg>System UI<svg class="icon"><use href="#i-chev-down"/></svg></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Canvas grid</div><div class="desc">Blueprint coordinate grid behind the chart.</div></div>
+              <div class="s-ctrl"><div class="toggle on" role="switch" aria-checked="true"></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Selection glow</div><div class="desc">Soft accent lens under the selected subtree.</div></div>
+              <div class="s-ctrl"><div class="toggle on" role="switch" aria-checked="true"></div></div>
+            </div>
+          </div>
+
+          <!-- LAYOUT -->
+          <div class="settings-panel" data-panel="layout">
+            <div class="panel-title">Layout</div>
+            <div class="panel-desc">How nodes are arranged and connected.</div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Direction</div><div class="desc">Growth axis of the tree.</div></div>
+              <div class="s-ctrl"><div class="seg"><button class="on">Top-down</button><button>Left-right</button></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Level spacing</div><div class="desc">Vertical gap between tiers.</div></div>
+              <div class="s-ctrl"><div class="slider"><div class="track"><div class="fill" style="width:56%"></div><div class="knob" style="left:56%"></div></div><span class="sval">72 px</span></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Sibling spacing</div><div class="desc">Horizontal gap between peers.</div></div>
+              <div class="s-ctrl"><div class="slider"><div class="track"><div class="fill" style="width:40%"></div><div class="knob" style="left:40%"></div></div><span class="sval">24 px</span></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Connector width</div><div class="desc">Stroke weight of reporting lines.</div></div>
+              <div class="s-ctrl"><div class="slider"><div class="track"><div class="fill" style="width:28%"></div><div class="knob" style="left:28%"></div></div><span class="sval">1.4 px</span></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Group IC stacks</div><div class="desc">Wrap leaf reports in a subtle well.</div></div>
+              <div class="s-ctrl"><div class="toggle on" role="switch" aria-checked="true"></div></div>
+            </div>
+          </div>
+
+          <!-- CARDS & BADGES (default) -->
+          <div class="settings-panel active" data-panel="cards">
+            <div class="panel-title">Cards &amp; Badges</div>
+            <div class="panel-desc">Node card sizing and the level badge style.</div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Card width</div><div class="desc">Fixed width of every node card.</div></div>
+              <div class="s-ctrl"><div class="slider"><div class="track"><div class="fill" style="width:62%"></div><div class="knob" style="left:62%"></div></div><span class="sval">176 px</span></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Card padding</div><div class="desc">Inner spacing around card text.</div></div>
+              <div class="s-ctrl"><div class="slider"><div class="track"><div class="fill" style="width:45%"></div><div class="knob" style="left:45%"></div></div><span class="sval">16 px</span></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Show job titles</div><div class="desc">Second line under each name.</div></div>
+              <div class="s-ctrl"><div class="toggle on" role="switch" aria-checked="true"></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Level badge style</div><div class="desc">How the level chip renders on the card.</div></div>
+              <div class="s-ctrl"><div class="seg"><button class="on">Pill</button><button>Tag</button><button>Hidden</button></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Badge position</div><div class="desc">Corner the level badge sits in.</div></div>
+              <div class="s-ctrl"><div class="selbox">Top-right<svg class="icon"><use href="#i-chev-down"/></svg></div></div>
+            </div>
+          </div>
+
+          <!-- LEVELS & CATEGORIES -->
+          <div class="settings-panel" data-panel="levels">
+            <div class="panel-title">Levels &amp; Categories</div>
+            <div class="panel-desc">Map level codes to titles and manage category colors.</div>
+            <div class="setting" style="display:block;border-bottom:none;padding-bottom:var(--s3)">
+              <div class="s-label"><div class="name" style="margin-bottom:var(--s3)">Level mapping</div></div>
+              <div class="lvl-table">
+                <div class="lvl-line"><span class="code">E12</span><span class="map">Chief / C-Suite</span><span class="badge-prev">E12</span></div>
+                <div class="lvl-line"><span class="code">E10</span><span class="map">Vice President</span><span class="badge-prev">E10</span></div>
+                <div class="lvl-line"><span class="code">E8</span><span class="map">Director / Manager</span><span class="badge-prev">E8</span></div>
+                <div class="lvl-line"><span class="code">L7</span><span class="map">Staff</span><span class="badge-prev">L7</span></div>
+                <div class="lvl-line"><span class="code">L6</span><span class="map">Senior</span><span class="badge-prev">L6</span></div>
+                <div class="lvl-line"><span class="code">L5</span><span class="map">Mid</span><span class="badge-prev">L5</span></div>
+              </div>
+            </div>
+            <div class="setting" style="display:block">
+              <div class="s-label"><div class="name" style="margin-bottom:var(--s2)">Categories</div></div>
+              <div class="cat-line"><span class="sw" style="background:var(--cat-amber)"></span><span class="cn">Open Position</span><span class="hex">#F5B31B</span></div>
+              <div class="cat-line"><span class="sw" style="background:var(--cat-blue)"></span><span class="cn">Offer Pending</span><span class="hex">#4CB8F5</span></div>
+              <div class="cat-line"><span class="sw" style="background:var(--cat-violet)"></span><span class="cn">Future Start</span><span class="hex">#A78BFA</span></div>
+            </div>
+          </div>
+
+          <!-- PRESETS -->
+          <div class="settings-panel" data-panel="presets">
+            <div class="panel-title">Presets</div>
+            <div class="panel-desc">Full palette library. The active preset drives every accent.</div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Active preset</div><div class="desc">Emerald — teal accent on deep surfaces.</div></div>
+              <div class="s-ctrl"><button class="btn ghost"><svg class="icon icon-sm" style="vertical-align:-2px"><use href="#i-save"/></svg> Save current…</button></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Sync theme with preset</div><div class="desc">Switch dark/light when preset changes.</div></div>
+              <div class="s-ctrl"><div class="toggle on" role="switch" aria-checked="true"></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Apply to exports</div><div class="desc">Use preset colors in PNG / PDF output.</div></div>
+              <div class="s-ctrl"><div class="toggle" role="switch" aria-checked="false"></div></div>
+            </div>
+          </div>
+
+          <!-- DATA & BACKUP -->
+          <div class="settings-panel" data-panel="data">
+            <div class="panel-title">Data &amp; Backup</div>
+            <div class="panel-desc">Everything is stored locally in your browser.</div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Auto-save</div><div class="desc">Write working changes as you edit.</div></div>
+              <div class="s-ctrl"><div class="toggle on" role="switch" aria-checked="true"></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Default export format</div><div class="desc">Used by the Export button.</div></div>
+              <div class="s-ctrl"><div class="selbox">PNG (2×)<svg class="icon"><use href="#i-chev-down"/></svg></div></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name">Download backup</div><div class="desc">Export all charts &amp; version history as JSON.</div></div>
+              <div class="s-ctrl"><button class="btn ghost"><svg class="icon icon-sm" style="vertical-align:-2px"><use href="#i-download"/></svg> Download .json</button></div>
+            </div>
+            <div class="setting">
+              <div class="s-label"><div class="name" style="color:var(--danger)">Clear local data</div><div class="desc">Remove all charts from this browser.</div></div>
+              <div class="s-ctrl"><button class="btn ghost" style="color:var(--danger);border-color:color-mix(in srgb,var(--danger) 40%,transparent)">Clear…</button></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- live preview -->
+        <aside class="settings-preview">
+          <div class="preview-head">Live preview <span class="live-dot"><span class="d"></span>updates live</span></div>
+          <div class="mini-cards">
+            <div class="mini-card"><span class="mb">E12</span><div class="mn">Sarah Chen</div><div class="mt">Chief Executive Officer</div></div>
+            <div class="mini-conn"></div>
+            <div class="mini-card sel"><span class="mb">E10</span><div class="mn">Marcus Johnson</div><div class="mt">VP Engineering</div></div>
+            <div class="mini-conn"></div>
+            <div class="mini-card"><span class="mb">E8</span><div class="mn">David Kim</div><div class="mt">Senior Engineering Manager</div></div>
+          </div>
+        </aside>
+      </div>
+
+      <div class="settings-foot">
+        <span class="foot-note">6 groups · 34 settings · changes apply instantly</span>
+        <button class="btn ghost" id="settings-cancel">Cancel</button>
+        <button class="btn primary" id="settings-done">Done</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ===================== COMMAND PALETTE ===================== -->
+  <div class="overlay" id="palette-overlay" role="dialog" aria-modal="true" aria-label="Command palette">
+    <div class="palette active">
+      <div class="palette-input">
+        <svg class="icon"><use href="#i-search"/></svg>
+        <input placeholder="Type a command or search people…" aria-label="Command palette" id="palette-search">
+        <button class="esc kbd" id="palette-close" aria-label="Close command palette">Esc</button>
+      </div>
+      <div class="palette-body">
+        <div class="pal-group">Actions</div>
+        <button class="pal-item active">
+          <span class="pic"><svg class="icon"><use href="#i-plus"/></svg></span>
+          <span class="plabel">Add report to Marcus Johnson</span>
+          <span class="keys"><span class="kbd">⏎</span></span>
+        </button>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-save"/></svg></span>
+          <span class="plabel">Save a version</span>
+          <span class="psub">3 edits since last version</span>
+          <span class="keys"><span class="kbd">⌘S</span></span>
+        </button>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-focus"/></svg></span>
+          <span class="plabel">Focus on selection</span>
+          <span class="keys"><span class="kbd">F</span></span>
+        </button>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-moon"/></svg></span>
+          <span class="plabel">Toggle theme</span>
+          <span class="keys"><span class="kbd">⌘⇧L</span></span>
+        </button>
+        <div class="pal-group">Navigate &amp; manage</div>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-download"/></svg></span>
+          <span class="plabel">Import from CSV…</span>
+          <span class="keys"><span class="kbd">⌘I</span></span>
+        </button>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-upload"/></svg></span>
+          <span class="plabel">Export as PNG…</span>
+          <span class="keys"><span class="kbd">⌘E</span></span>
+        </button>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-sliders"/></svg></span>
+          <span class="plabel">Open settings</span>
+          <span class="keys"><span class="kbd">⌘,</span></span>
+        </button>
+        <button class="pal-item">
+          <span class="pic"><svg class="icon"><use href="#i-fit"/></svg></span>
+          <span class="plabel">Fit chart to screen</span>
+          <span class="keys"><span class="kbd">⇧1</span></span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script>
+(function () {
+  var app = document.getElementById('app');
+
+  // ---- Theme toggle ----
+  document.getElementById('theme-toggle').addEventListener('click', function () {
+    app.setAttribute('data-theme', app.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  });
+
+  // ---- Inspector open/close ----
+  document.getElementById('inspector-close').addEventListener('click', function () {
+    app.classList.add('inspector-collapsed');
+  });
+  var marcus = document.getElementById('node-marcus');
+  function openInspector() { app.classList.remove('inspector-collapsed'); }
+  marcus.addEventListener('click', openInspector);
+  marcus.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openInspector(); }
+  });
+
+  // ---- Overlays ----
+  var settings = document.getElementById('settings-overlay');
+  var palette  = document.getElementById('palette-overlay');
+  function openOv(o) { o.classList.add('open'); }
+  function closeOv(o) { o.classList.remove('open'); }
+
+  document.getElementById('settings-btn').addEventListener('click', function () { openOv(settings); });
+  document.getElementById('settings-close').addEventListener('click', function () { closeOv(settings); });
+  document.getElementById('settings-cancel').addEventListener('click', function () { closeOv(settings); });
+  document.getElementById('settings-done').addEventListener('click', function () { closeOv(settings); });
+
+  document.getElementById('palette-btn').addEventListener('click', function () {
+    openOv(palette);
+    var s = document.getElementById('palette-search'); if (s) s.focus();
+  });
+  document.getElementById('palette-close').addEventListener('click', function () { closeOv(palette); });
+
+  // Close on backdrop click
+  [settings, palette].forEach(function (ov) {
+    ov.addEventListener('mousedown', function (e) { if (e.target === ov) closeOv(ov); });
+  });
+
+  // ---- Settings group nav ----
+  var navBtns = document.querySelectorAll('.settings-nav button');
+  var panels  = document.querySelectorAll('.settings-panel');
+  navBtns.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      navBtns.forEach(function (b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      var g = btn.getAttribute('data-group');
+      panels.forEach(function (p) {
+        p.classList.toggle('active', p.getAttribute('data-panel') === g);
+      });
+    });
+  });
+
+  // ---- Keyboard ----
+  document.addEventListener('keydown', function (e) {
+    var mod = e.metaKey || e.ctrlKey;
+    if (mod && (e.key === 'k' || e.key === 'K')) {
+      e.preventDefault();
+      if (palette.classList.contains('open')) { closeOv(palette); }
+      else { openOv(palette); var s = document.getElementById('palette-search'); if (s) s.focus(); }
+    }
+    if (e.key === 'Escape') { closeOv(palette); closeOv(settings); }
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/design/mocks/direction-b.html
+++ b/docs/design/mocks/direction-b.html
@@ -1,0 +1,1181 @@
+<!-- The chart-canvas areas in this mock are illustrative stand-ins. The production chart rendering, style presets, and layout engine are final as-is (owner decision, 2026-07-16). -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<!-- interactive: #theme-toggle, #cmd-btn, #palette, #palette-close, #palette-input, #inspector-close, #node-marcus, #compare-toggle, #compare-exit -->
+<title>Arbol Studio — Org design instrument</title>
+<style>
+  /* ============================================================
+     ARBOL STUDIO — design tokens
+     Dark-default, warm graphite/ink. Teal = working accent.
+     Amber = time / history. Emerald / rose / amber = diff.
+     ============================================================ */
+  #app {
+    /* surfaces — warm graphite (nudged off pure-neutral toward ink) */
+    --bg-base: #141317;
+    --bg-canvas: #0e0d10;
+    --bg-surface: #1b1a1f;
+    --bg-elevated: #232128;
+    --bg-hover: #2a2830;
+    --bg-active: #322f39;
+
+    --card-bg: #1f1d24;
+    --card-bg-hover: #27242d;
+
+    --border-subtle: rgba(190,180,205,0.07);
+    --border-default: rgba(190,180,205,0.13);
+    --border-strong: rgba(190,180,205,0.22);
+    --edge: rgba(190,180,205,0.26);
+    --chip-bg: rgba(255,255,255,0.05);
+
+    --text-primary: #efecf3;
+    --text-secondary: #aba5b5;
+    --text-tertiary: #8b8494;
+
+    --accent: #1ec9b0;
+    --accent-hover: #17b39c;
+    --accent-soft: rgba(30,201,176,0.14);
+    --accent-line: rgba(30,201,176,0.55);
+    --accent-glow: rgba(30,201,176,0.30);
+
+    --amber: #f4b13e;
+    --amber-soft: rgba(244,177,62,0.15);
+    --amber-line: rgba(244,177,62,0.55);
+
+    --diff-add: #35d399;
+    --diff-add-soft: rgba(53,211,153,0.16);
+    --diff-remove: #fb5d74;
+    --diff-remove-soft: rgba(251,93,116,0.15);
+    --diff-move: #f4b13e;
+    --diff-move-soft: rgba(244,177,62,0.16);
+
+    --cat-open: #f4b13e;
+    --cat-offer: #4aa6ff;
+
+    --glass: rgba(27,26,31,0.72);
+
+    /* type */
+    --sans: ui-sans-serif, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+    --mono: ui-monospace, "SF Mono", "Cascadia Code", Consolas, monospace;
+
+    /* spacing (4px) */
+    --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:24px; --s7:32px; --s8:48px;
+
+    /* radii */
+    --r-sm:6px; --r-md:9px; --r-lg:13px; --r-xl:18px; --r-full:999px;
+
+    /* elevation */
+    --sh-sm: 0 1px 2px rgba(0,0,0,.5);
+    --sh-md: 0 6px 22px rgba(0,0,0,.45), 0 2px 6px rgba(0,0,0,.35);
+    --sh-lg: 0 24px 60px rgba(0,0,0,.55), 0 8px 20px rgba(0,0,0,.4);
+
+    --ease: cubic-bezier(.22,1,.36,1);
+    --grid: rgba(190,180,205,0.05);
+    --grid-strong: rgba(190,180,205,0.08);
+
+    color-scheme: dark;
+  }
+
+  #app[data-theme="light"] {
+    --bg-base: #efece7;
+    --bg-canvas: #e9e5df;
+    --bg-surface: #ffffff;
+    --bg-elevated: #ffffff;
+    --bg-hover: #f2efea;
+    --bg-active: #e6e1da;
+
+    --card-bg: #ffffff;
+    --card-bg-hover: #faf8f5;
+
+    --border-subtle: rgba(46,36,54,0.07);
+    --border-default: rgba(46,36,54,0.13);
+    --border-strong: rgba(46,36,54,0.22);
+    --edge: rgba(46,36,54,0.24);
+    --chip-bg: rgba(46,36,54,0.05);
+
+    --text-primary: #1c1922;
+    --text-secondary: #575060;
+    --text-tertiary: #6d6678;
+
+    --accent: #0d9488;
+    --accent-hover: #0b7d73;
+    --accent-soft: rgba(13,148,136,0.11);
+    --accent-line: rgba(13,148,136,0.6);
+    --accent-glow: rgba(13,148,136,0.20);
+
+    --amber: #c47a11;
+    --amber-soft: rgba(196,122,17,0.13);
+    --amber-line: rgba(196,122,17,0.55);
+
+    --diff-add: #0f9d63;
+    --diff-add-soft: rgba(15,157,99,0.13);
+    --diff-remove: #dc3a53;
+    --diff-remove-soft: rgba(220,58,83,0.12);
+    --diff-move: #c47a11;
+    --diff-move-soft: rgba(196,122,17,0.14);
+
+    --cat-open: #c47a11;
+    --cat-offer: #2b7fd6;
+
+    --glass: rgba(255,255,255,0.78);
+
+    --sh-sm: 0 1px 2px rgba(30,20,40,.08);
+    --sh-md: 0 6px 22px rgba(30,20,40,.10), 0 2px 6px rgba(30,20,40,.06);
+    --sh-lg: 0 24px 60px rgba(30,20,40,.16), 0 8px 20px rgba(30,20,40,.08);
+
+    --grid: rgba(46,36,54,0.055);
+    --grid-strong: rgba(46,36,54,0.09);
+
+    color-scheme: light;
+  }
+
+  /* ---------- reset-ish ---------- */
+  #app, #app * { box-sizing: border-box; }
+  #app {
+    font-family: var(--sans);
+    color: var(--text-primary);
+    background: var(--bg-base);
+    height: 100vh;
+    display: grid;
+    grid-template-columns: 56px 272px 1fr;
+    grid-template-rows: 54px 1fr auto auto;
+    grid-template-areas:
+      "rail header header"
+      "rail panel  canvas"
+      "rail timeline timeline"
+      "rail footnote footnote";
+    overflow: hidden;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  #app button { font-family: inherit; cursor: pointer; color: inherit; background: none; border: none; }
+  #app :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-sm); }
+  #app .icon { width: 18px; height: 18px; flex: none; stroke-width: 1.85; }
+  .eyebrow {
+    font-size: 10px; font-weight: 700; letter-spacing: .13em; text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+  .num { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+
+  /* ================= ICON RAIL ================= */
+  .rail {
+    grid-area: rail;
+    background: var(--bg-surface);
+    border-right: 1px solid var(--border-subtle);
+    display: flex; flex-direction: column; align-items: center;
+    padding: 10px 0; gap: 4px;
+  }
+  .rail-logo {
+    width: 34px; height: 34px; border-radius: var(--r-md);
+    display: grid; place-items: center; margin-bottom: 10px;
+    background: linear-gradient(150deg, var(--accent), var(--accent-hover));
+    color: #05201c; box-shadow: 0 0 0 1px var(--border-default), var(--sh-sm);
+  }
+  .rail-logo .icon { width: 20px; height: 20px; stroke-width: 2.1; }
+  .rail-btn {
+    width: 40px; height: 40px; border-radius: var(--r-md);
+    display: grid; place-items: center; color: var(--text-tertiary);
+    position: relative; transition: color .15s var(--ease), background .15s var(--ease);
+  }
+  .rail-btn:hover { color: var(--text-secondary); background: var(--bg-hover); }
+  .rail-btn.active { color: var(--accent); background: var(--accent-soft); }
+  .rail-btn.active::before {
+    content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px; width: 3px;
+    border-radius: 0 3px 3px 0; background: var(--accent);
+  }
+  .rail-spacer { flex: 1; }
+
+  /* ================= HEADER ================= */
+  .header {
+    grid-area: header;
+    display: flex; align-items: center; gap: var(--s4);
+    padding: 0 var(--s5) 0 var(--s5);
+    border-bottom: 1px solid var(--border-subtle);
+    background: var(--bg-base);
+  }
+  .crumb { display: flex; align-items: center; gap: 9px; min-width: 0; }
+  .crumb-name { font-weight: 700; font-size: 14px; letter-spacing: -.01em; white-space: nowrap; }
+  .crumb-sep { color: var(--text-tertiary); }
+  .save-state {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 12px; color: var(--text-secondary);
+    padding: 4px 9px; border-radius: var(--r-full); background: var(--chip-bg);
+  }
+  .save-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .hdr-tools { display: flex; align-items: center; gap: 2px; margin-left: auto; }
+  .icon-btn {
+    width: 34px; height: 34px; border-radius: var(--r-md);
+    display: grid; place-items: center; color: var(--text-secondary);
+    transition: background .15s var(--ease), color .15s var(--ease);
+  }
+  .icon-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .divider-v { width: 1px; height: 22px; background: var(--border-default); margin: 0 8px; }
+
+  /* Command button — command-first pillar */
+  .cmd-btn {
+    display: inline-flex; align-items: center; gap: 10px;
+    height: 34px; padding: 0 10px 0 12px; border-radius: var(--r-md);
+    background: var(--bg-elevated); border: 1px solid var(--border-default);
+    color: var(--text-secondary); font-size: 13px; font-weight: 500;
+    transition: border-color .15s var(--ease), background .15s var(--ease), box-shadow .15s var(--ease);
+  }
+  .cmd-btn:hover { border-color: var(--accent-line); color: var(--text-primary); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .cmd-btn .icon { width: 15px; height: 15px; color: var(--accent); }
+  .kbd {
+    font-family: var(--mono); font-size: 11px; font-weight: 600;
+    padding: 2px 6px; border-radius: 5px; color: var(--text-secondary);
+    background: var(--chip-bg); border: 1px solid var(--border-subtle);
+    line-height: 1;
+  }
+
+  /* ================= CHARTS PANEL ================= */
+  .panel {
+    grid-area: panel;
+    background: var(--bg-surface);
+    border-right: 1px solid var(--border-subtle);
+    display: flex; flex-direction: column; min-height: 0;
+  }
+  .panel-head {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 16px 16px 10px;
+  }
+  .panel-add {
+    width: 26px; height: 26px; border-radius: var(--r-sm); display: grid; place-items: center;
+    color: var(--text-secondary); background: var(--chip-bg);
+    transition: background .15s var(--ease), color .15s var(--ease);
+  }
+  .panel-add:hover { background: var(--accent-soft); color: var(--accent); }
+  .panel-search {
+    margin: 0 12px 8px; height: 32px; border-radius: var(--r-md);
+    display: flex; align-items: center; gap: 8px; padding: 0 10px;
+    background: var(--bg-base); border: 1px solid var(--border-default);
+    color: var(--text-tertiary); font-size: 12.5px;
+  }
+  .panel-search .icon { width: 14px; height: 14px; }
+  .chart-list { padding: 4px 8px; display: flex; flex-direction: column; gap: 2px; }
+  .chart-row {
+    display: flex; align-items: center; gap: 10px; padding: 9px 10px;
+    border-radius: var(--r-md); border: 1px solid transparent; position: relative;
+    transition: background .15s var(--ease);
+  }
+  .chart-row:hover { background: var(--bg-hover); }
+  .chart-row.active { background: var(--accent-soft); border-color: var(--accent-line); }
+  .chart-ico {
+    width: 30px; height: 30px; border-radius: var(--r-sm); flex: none;
+    display: grid; place-items: center; color: var(--accent);
+    background: var(--accent-soft);
+  }
+  .chart-row.active .chart-ico { background: var(--bg-surface); }
+  .chart-meta { min-width: 0; flex: 1; }
+  .chart-nm { font-size: 13px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .chart-sub { font-size: 11px; color: var(--text-tertiary); margin-top: 1px; }
+  .row-actions { display: flex; gap: 1px; }
+  .row-actions .mini {
+    width: 24px; height: 24px; border-radius: var(--r-sm); display: grid; place-items: center;
+    color: var(--text-tertiary); transition: background .12s var(--ease), color .12s var(--ease);
+  }
+  .row-actions .mini:hover { background: var(--bg-active); color: var(--text-primary); }
+  .row-actions .icon { width: 15px; height: 15px; }
+
+  .panel-section { margin-top: auto; padding: 14px 16px; border-top: 1px solid var(--border-subtle); }
+  .legend-row { display: flex; align-items: center; gap: 9px; font-size: 12px; color: var(--text-secondary); padding: 5px 0; }
+  .legend-dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+  .legend-count { margin-left: auto; font-size: 11px; color: var(--text-tertiary); }
+
+  /* ================= CANVAS ================= */
+  .canvas {
+    grid-area: canvas; position: relative; min-width: 0; overflow: hidden;
+    background:
+      radial-gradient(120% 90% at 60% 0%, rgba(30,201,176,0.05), transparent 60%),
+      var(--bg-canvas);
+  }
+  .canvas-grid {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px),
+      linear-gradient(var(--grid-strong) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid-strong) 1px, transparent 1px);
+    background-size: 28px 28px, 28px 28px, 140px 140px, 140px 140px;
+    mask-image: radial-gradient(120% 120% at 50% 40%, #000 55%, transparent 100%);
+    -webkit-mask-image: radial-gradient(120% 120% at 50% 40%, #000 55%, transparent 100%);
+  }
+  .stage {
+    position: absolute; inset: 0; display: grid; place-items: center;
+    padding: 40px 32px 24px;
+  }
+  .org-svg { width: 100%; max-width: 1440px; height: auto; overflow: visible; }
+
+  /* org svg */
+  .edge { fill: none; stroke: var(--edge); stroke-width: 1.5; }
+  .node { cursor: default; }
+  #node-marcus { cursor: pointer; }
+  .card { fill: var(--card-bg); stroke: var(--border-default); stroke-width: 1; transition: fill .15s var(--ease), stroke .15s var(--ease); }
+  .node:hover .card { fill: var(--card-bg-hover); stroke: var(--border-strong); }
+  .node.selected .card { stroke: var(--accent); stroke-width: 1.5; }
+  .sel-ring { fill: none; stroke: var(--accent); stroke-width: 1.5; opacity: .4; }
+  .mono-bg { fill: var(--accent-soft); }
+  .mono-t { fill: var(--accent); font: 700 10px var(--mono); text-anchor: middle; letter-spacing: .3px; }
+  .nm { fill: var(--text-primary); font: 700 13.5px var(--sans); letter-spacing: -.01em; }
+  .ti { fill: var(--text-secondary); font: 400 10px var(--sans); }
+  .lvl { fill: var(--chip-bg); stroke: var(--border-subtle); stroke-width: 1; }
+  .lvl-t { fill: var(--text-secondary); font: 600 9px var(--mono); text-anchor: middle; letter-spacing: .4px; }
+  .cat { stroke: var(--card-bg); stroke-width: 1.5; }
+  .cat-open { fill: var(--cat-open); }
+  .cat-offer { fill: var(--cat-offer); }
+
+  /* diff overlay (compare mode) */
+  .diff-only { display: none; }
+  #app.comparing .diff-only { display: block; }
+  #app.comparing #base-edges .edge { opacity: .35; }
+  #app.comparing .node:not(.chg) .card { opacity: .82; }
+  .edge-add { fill: none; stroke: var(--diff-add); stroke-width: 2.2; }
+  .edge-move { fill: none; stroke: var(--diff-move); stroke-width: 2.2; }
+  .edge-remove { fill: none; stroke: var(--diff-remove); stroke-width: 2; stroke-dasharray: 6 5; }
+  .ring-add { fill: none; stroke: var(--diff-add); stroke-width: 2; }
+  .ring-move { fill: none; stroke: var(--diff-move); stroke-width: 2; }
+  .dbadge-c { stroke: var(--bg-canvas); stroke-width: 2; }
+  .dbadge-add { fill: var(--diff-add); }
+  .dbadge-move { fill: var(--diff-move); }
+  .dbadge-rem { fill: var(--diff-remove); }
+  .dbadge-g { stroke: #05130d; stroke-width: 1.6; stroke-linecap: round; fill: none; }
+  .ghost .g-card { fill: var(--diff-remove-soft); stroke: var(--diff-remove); stroke-width: 1.4; stroke-dasharray: 6 5; }
+  .ghost .g-nm { fill: var(--diff-remove); font: 700 12px var(--sans); }
+  .ghost .g-ti { fill: var(--diff-remove); opacity: .8; font: 400 9.5px var(--sans); }
+
+  /* floating canvas toolbar */
+  .canvas-tools {
+    position: absolute; left: 20px; bottom: 20px; z-index: 5;
+    display: flex; align-items: center; gap: 2px; padding: 4px;
+    background: var(--glass); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+    border: 1px solid var(--border-default); border-radius: var(--r-lg); box-shadow: var(--sh-md);
+  }
+  .ctool {
+    width: 32px; height: 32px; border-radius: var(--r-md); display: grid; place-items: center;
+    color: var(--text-secondary); transition: background .12s var(--ease), color .12s var(--ease);
+  }
+  .ctool:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .ctool.on { color: var(--accent); background: var(--accent-soft); }
+  .ctool .icon { width: 17px; height: 17px; }
+  .ctool-sep { width: 1px; height: 18px; background: var(--border-default); margin: 0 3px; }
+  .zoom-val { padding: 0 8px; font-size: 12px; color: var(--text-secondary); font-family: var(--mono); }
+
+  /* compare banner on canvas */
+  .compare-flag {
+    position: absolute; top: 16px; left: 50%; transform: translateX(-50%); z-index: 6;
+    display: none; align-items: center; gap: 12px; padding: 8px 10px 8px 14px;
+    background: var(--glass); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+    border: 1px solid var(--amber-line); border-radius: var(--r-full); box-shadow: var(--sh-md);
+    font-size: 12.5px; color: var(--text-secondary);
+  }
+  #app.comparing .compare-flag { display: flex; }
+  .compare-flag b { color: var(--text-primary); font-weight: 600; }
+  .cf-swatch { display: inline-flex; align-items: center; gap: 6px; }
+  .cf-a, .cf-b { width: 9px; height: 9px; border-radius: 50%; }
+  .cf-a { background: var(--amber); }
+  .cf-b { background: var(--accent); }
+  .cf-arrow { color: var(--text-tertiary); }
+
+  /* ================= INSPECTOR ================= */
+  .inspector {
+    position: absolute; top: 16px; right: 16px; bottom: 16px; width: 340px; z-index: 8;
+    background: var(--glass); backdrop-filter: blur(20px) saturate(1.3); -webkit-backdrop-filter: blur(20px) saturate(1.3);
+    border: 1px solid var(--border-default); border-radius: var(--r-xl);
+    box-shadow: var(--sh-lg); display: flex; flex-direction: column; overflow: hidden;
+    transition: transform .28s var(--ease), opacity .28s var(--ease);
+  }
+  .inspector.hidden { transform: translateX(24px) scale(.99); opacity: 0; pointer-events: none; }
+  .insp-top { display: flex; align-items: flex-start; gap: 12px; padding: 18px 16px 14px; }
+  .insp-mono {
+    width: 44px; height: 44px; border-radius: var(--r-md); flex: none;
+    display: grid; place-items: center; font: 700 15px var(--mono); letter-spacing: .5px;
+    background: linear-gradient(150deg, var(--accent-soft), transparent); color: var(--accent);
+    border: 1px solid var(--accent-line);
+  }
+  .insp-id { flex: 1; min-width: 0; }
+  .insp-name { font-size: 17px; font-weight: 800; letter-spacing: -.02em; }
+  .insp-title { font-size: 13px; color: var(--text-secondary); margin-top: 1px; }
+  .insp-close {
+    width: 30px; height: 30px; border-radius: var(--r-md); display: grid; place-items: center;
+    color: var(--text-tertiary); transition: background .12s var(--ease), color .12s var(--ease);
+  }
+  .insp-close:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .insp-body { flex: 1; overflow-y: auto; padding: 0 16px 16px; }
+
+  .mapped {
+    display: flex; align-items: center; gap: 10px; padding: 10px 12px; margin: 2px 0 16px;
+    background: var(--bg-base); border: 1px solid var(--border-default); border-radius: var(--r-md);
+  }
+  .mapped .icon { width: 15px; height: 15px; color: var(--accent); }
+  .mapped-txt { flex: 1; min-width: 0; }
+  .mapped-lbl { font-size: 10px; letter-spacing: .1em; text-transform: uppercase; color: var(--text-tertiary); }
+  .mapped-val { font-size: 13px; font-weight: 600; }
+  .pin {
+    display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 600;
+    color: var(--accent); background: var(--accent-soft); padding: 4px 8px; border-radius: var(--r-full);
+  }
+  .pin .icon { width: 12px; height: 12px; color: inherit; }
+
+  .insp-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 8px; margin-bottom: 18px; }
+  .stat {
+    padding: 11px 10px; border-radius: var(--r-md);
+    background: var(--bg-base); border: 1px solid var(--border-subtle);
+  }
+  .stat-v { font-size: 20px; font-weight: 800; letter-spacing: -.02em; font-variant-numeric: tabular-nums; }
+  .stat-l { font-size: 9.5px; letter-spacing: .09em; text-transform: uppercase; color: var(--text-tertiary); margin-top: 3px; }
+
+  .field { margin-bottom: 16px; }
+  .field > .eyebrow { display: block; margin-bottom: 8px; }
+  .level-line { display: flex; align-items: center; gap: 8px; }
+  .level-pill {
+    font-family: var(--mono); font-weight: 700; font-size: 13px; letter-spacing: .5px;
+    padding: 3px 10px; border-radius: var(--r-sm); background: var(--accent-soft); color: var(--accent);
+  }
+  .level-band { flex: 1; height: 5px; border-radius: var(--r-full); background: var(--chip-bg); overflow: hidden; }
+  .level-fill { height: 100%; width: 83%; border-radius: var(--r-full); background: linear-gradient(90deg, var(--accent), var(--accent-hover)); }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 500;
+    padding: 5px 10px; border-radius: var(--r-full); border: 1px solid var(--border-default);
+    color: var(--text-secondary); transition: border-color .12s var(--ease), color .12s var(--ease);
+  }
+  .chip .dot { width: 7px; height: 7px; border-radius: 50%; }
+  .chip.sel { border-color: var(--accent-line); color: var(--text-primary); background: var(--accent-soft); }
+  .chip.sel::after { content: ""; }
+
+  .insp-actions { padding: 12px 16px; border-top: 1px solid var(--border-subtle); background: var(--bg-surface); }
+  .btn-primary {
+    width: 100%; height: 38px; border-radius: var(--r-md); font-size: 13px; font-weight: 600;
+    display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+    background: linear-gradient(150deg, var(--accent), var(--accent-hover)); color: #04211d;
+    box-shadow: var(--sh-sm); transition: filter .15s var(--ease), transform .1s var(--ease);
+  }
+  .btn-primary:hover { filter: brightness(1.06); }
+  .btn-primary:active { transform: translateY(1px); }
+  .btn-primary .icon { width: 16px; height: 16px; }
+  .action-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 8px; }
+  .btn-ghost {
+    height: 34px; border-radius: var(--r-md); font-size: 12.5px; font-weight: 500;
+    display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+    border: 1px solid var(--border-default); color: var(--text-secondary);
+    transition: background .12s var(--ease), color .12s var(--ease), border-color .12s var(--ease);
+  }
+  .btn-ghost:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .btn-ghost.danger:hover { color: var(--diff-remove); border-color: var(--diff-remove); background: var(--diff-remove-soft); }
+  .btn-ghost .icon { width: 15px; height: 15px; }
+
+  /* ================= TIMELINE (signature) ================= */
+  .timeline {
+    grid-area: timeline; position: relative;
+    background: var(--bg-surface); border-top: 1px solid var(--border-default);
+    display: grid; grid-template-columns: auto 1fr auto; align-items: center;
+    gap: 22px; padding: 14px 22px 16px; min-height: 104px;
+  }
+  #app.comparing .timeline { border-top-color: var(--amber-line); }
+  .tl-head { display: flex; flex-direction: column; gap: 3px; min-width: 128px; }
+  .tl-head .eyebrow { display: inline-flex; align-items: center; gap: 6px; }
+  .tl-head .icon { width: 13px; height: 13px; color: var(--amber); }
+  .tl-sub { font-size: 12px; color: var(--text-secondary); }
+  .tl-sub b { color: var(--text-primary); font-weight: 700; }
+
+  .tl-track { position: relative; height: 66px; }
+  .tl-axis {
+    position: absolute; left: 0; right: 0; top: 33px; height: 2px; border-radius: 2px;
+    background: linear-gradient(90deg, transparent, var(--border-strong) 6%, var(--border-strong) 94%, transparent);
+  }
+  .tl-months {
+    position: absolute; left: 0; right: 0; bottom: -2px; display: flex; justify-content: space-between;
+    font-size: 9.5px; letter-spacing: .08em; text-transform: uppercase; color: var(--text-tertiary);
+    font-family: var(--mono);
+  }
+  .tl-range {
+    display: none; position: absolute; top: 24px; height: 20px; border-radius: var(--r-full);
+    left: 30%; right: 6%;
+    background: linear-gradient(90deg, var(--amber-soft), var(--accent-soft));
+    border: 1px solid var(--amber-line);
+  }
+  #app.comparing .tl-range { display: block; }
+
+  .snap {
+    position: absolute; top: 0; transform: translateX(-50%);
+    display: flex; flex-direction: column; align-items: center; gap: 0;
+  }
+  .snap, .work { position: absolute; }
+  .snap-lbl {
+    font-size: 10.5px; font-weight: 600; color: var(--text-secondary); white-space: nowrap;
+    margin-bottom: 4px; transition: color .15s var(--ease);
+  }
+  .snap-dot {
+    width: 13px; height: 13px; border-radius: 50%; margin-top: 27px;
+    background: var(--amber); border: 2px solid var(--bg-surface);
+    box-shadow: 0 0 0 1px var(--amber-line); transition: transform .15s var(--ease), box-shadow .15s var(--ease);
+  }
+  .snap:hover .snap-dot { transform: scale(1.18); }
+  .snap:hover .snap-lbl { color: var(--text-primary); }
+  .snap-ab {
+    position: absolute; top: 39px; left: 50%; transform: translateX(-50%);
+    font: 700 9px var(--mono); color: #241a05;
+    background: var(--amber); width: 16px; height: 16px; border-radius: 50%;
+    display: none; place-items: center; box-shadow: 0 0 0 2px var(--bg-surface); z-index: 2;
+  }
+  #app.comparing .snap.pick-a .snap-dot,
+  #app.comparing .snap.pick-b .snap-dot { transform: scale(1.15); }
+  #app.comparing .snap.pick-a .snap-ab { display: grid; }
+  #app.comparing .snap.pick-a .snap-lbl,
+  #app.comparing .snap.pick-b .snap-lbl { color: var(--text-primary); }
+
+  /* working state — pulsing open dot */
+  .work { position: absolute; top: 0; transform: translateX(-50%); display: flex; flex-direction: column; align-items: center; }
+  .work-lbl { font-size: 10.5px; font-weight: 700; color: var(--accent); white-space: nowrap; margin-bottom: 4px; }
+  .work-dot {
+    position: relative; width: 14px; height: 14px; border-radius: 50%; margin-top: 26px;
+    background: var(--bg-surface); border: 2.5px solid var(--accent);
+  }
+  .work-dot::after {
+    content: ""; position: absolute; inset: -5px; border-radius: 50%;
+    border: 2px solid var(--accent); opacity: 0; animation: pulse 2.4s var(--ease) infinite;
+  }
+  #app.comparing .work .snap-ab { display: grid; background: var(--accent); color: #04211d; box-shadow: 0 0 0 2px var(--bg-surface); }
+  #app.comparing .work-lbl { color: var(--accent); }
+  @keyframes pulse { 0% { opacity: .8; transform: scale(.7); } 70% { opacity: 0; transform: scale(1.5); } 100% { opacity: 0; } }
+
+  .tl-actions { display: flex; align-items: center; gap: 10px; min-width: 128px; justify-content: flex-end; }
+  .btn-compare {
+    display: inline-flex; align-items: center; gap: 8px; height: 34px; padding: 0 14px;
+    border-radius: var(--r-md); font-size: 13px; font-weight: 600; color: var(--text-primary);
+    background: var(--bg-elevated); border: 1px solid var(--border-default);
+    transition: border-color .15s var(--ease), box-shadow .15s var(--ease);
+  }
+  .btn-compare:hover { border-color: var(--amber-line); box-shadow: 0 0 0 3px var(--amber-soft); }
+  .btn-compare .icon { width: 15px; height: 15px; color: var(--amber); }
+  #app.comparing .btn-compare { display: none; }
+
+  .diff-chips { display: none; align-items: center; gap: 8px; }
+  #app.comparing .diff-chips { display: flex; }
+  .dchip {
+    display: inline-flex; align-items: center; gap: 6px; font-size: 12px; font-weight: 600;
+    padding: 5px 10px; border-radius: var(--r-full); font-variant-numeric: tabular-nums;
+  }
+  .dchip .d { width: 8px; height: 8px; border-radius: 2px; }
+  .dchip.add { color: var(--diff-add); background: var(--diff-add-soft); }
+  .dchip.add .d { background: var(--diff-add); }
+  .dchip.move { color: var(--diff-move); background: var(--diff-move-soft); }
+  .dchip.move .d { background: var(--diff-move); border-radius: 50%; }
+  .dchip.rem { color: var(--diff-remove); background: var(--diff-remove-soft); }
+  .dchip.rem .d { background: var(--diff-remove); border-radius: 50%; }
+  .exit-btn {
+    display: inline-flex; align-items: center; gap: 6px; height: 30px; padding: 0 12px;
+    border-radius: var(--r-md); font-size: 12.5px; font-weight: 600; color: var(--text-secondary);
+    border: 1px solid var(--border-default); margin-left: 2px;
+    transition: background .12s var(--ease), color .12s var(--ease);
+  }
+  .exit-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+  .exit-btn .icon { width: 14px; height: 14px; }
+
+  /* ================= FOOTNOTE ================= */
+  .footnote {
+    grid-area: footnote; display: flex; align-items: center; gap: 10px;
+    padding: 7px 22px; font-size: 11.5px; color: var(--text-tertiary);
+    background: var(--bg-base); border-top: 1px solid var(--border-subtle);
+  }
+  .footnote .icon { width: 13px; height: 13px; color: var(--accent); }
+  .footnote b { color: var(--text-secondary); font-weight: 600; }
+  .foot-ver { margin-left: auto; font-family: var(--mono); font-size: 11px; }
+
+  /* ================= COMMAND PALETTE ================= */
+  .palette-scrim {
+    position: fixed; inset: 0; z-index: 40; display: none;
+    background: rgba(6,5,9,.55); backdrop-filter: blur(4px); -webkit-backdrop-filter: blur(4px);
+    align-items: flex-start; justify-content: center; padding-top: 12vh;
+  }
+  .palette-scrim.open { display: flex; }
+  .palette {
+    width: min(600px, 92vw); max-height: 66vh; display: flex; flex-direction: column;
+    background: var(--bg-elevated); border: 1px solid var(--border-strong);
+    border-radius: var(--r-xl); box-shadow: var(--sh-lg); overflow: hidden;
+    animation: pop .22s var(--ease);
+  }
+  @keyframes pop { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+  .pal-input-wrap { display: flex; align-items: center; gap: 12px; padding: 15px 18px; border-bottom: 1px solid var(--border-subtle); }
+  .pal-input-wrap .icon { width: 19px; height: 19px; color: var(--text-tertiary); }
+  #palette-input {
+    flex: 1; background: none; border: none; outline: none; color: var(--text-primary);
+    font-family: var(--sans); font-size: 15px;
+  }
+  #palette-input::placeholder { color: var(--text-tertiary); }
+  .pal-esc { font-size: 11px; color: var(--text-tertiary); border: 1px solid var(--border-default); padding: 3px 7px; border-radius: 5px; font-family: var(--mono); }
+  .pal-body { overflow-y: auto; padding: 8px; }
+  .pal-group-lbl { padding: 10px 12px 6px; }
+  .pal-item {
+    display: flex; align-items: center; gap: 13px; width: 100%; text-align: left;
+    padding: 9px 12px; border-radius: var(--r-md); color: var(--text-secondary);
+    transition: background .1s var(--ease), color .1s var(--ease);
+  }
+  .pal-item:hover, .pal-item.cur { background: var(--accent-soft); color: var(--text-primary); }
+  .pal-ico { width: 30px; height: 30px; border-radius: var(--r-sm); flex: none; display: grid; place-items: center; background: var(--chip-bg); color: var(--text-secondary); }
+  .pal-item:hover .pal-ico, .pal-item.cur .pal-ico { background: var(--bg-surface); color: var(--accent); }
+  .pal-ico .icon { width: 16px; height: 16px; }
+  .pal-label { flex: 1; font-size: 13.5px; font-weight: 500; color: var(--text-primary); }
+  .pal-hint { display: flex; gap: 4px; }
+  .pal-empty { padding: 26px; text-align: center; color: var(--text-tertiary); font-size: 13px; display: none; }
+
+  @media (prefers-reduced-motion: reduce) {
+    #app *, .palette, .palette-scrim { animation: none !important; transition: none !important; }
+  }
+
+  /* keep the frame from ever pushing the page horizontally */
+  @media (max-width: 1180px) {
+    #app { grid-template-columns: 56px 232px 1fr; }
+    .inspector { width: 312px; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ========================= ICON SPRITE ========================= -->
+<svg style="display:none" aria-hidden="true"><defs>
+  <symbol id="icon-tree" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="2.4"/><circle cx="6" cy="19" r="2.4"/><circle cx="18" cy="19" r="2.4"/><path d="M12 7.4v3.1M6 16.6v-1.4a3 3 0 0 1 3-3h6a3 3 0 0 1 3 3v1.4"/></symbol>
+  <symbol id="icon-charts" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="3" width="6" height="5" rx="1.2"/><rect x="3" y="16" width="6" height="5" rx="1.2"/><rect x="15" y="16" width="6" height="5" rx="1.2"/><path d="M12 8v4M6 16v-2a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v2"/></symbol>
+  <symbol id="icon-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></symbol>
+  <symbol id="icon-analytics" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4v16h16"/><path d="M8 16v-4M13 16V8M18 16v-7"/></symbol>
+  <symbol id="icon-transfer" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M17 3v12M17 15l-3.5-3.5M17 15l3.5-3.5M7 21V9M7 9L3.5 12.5M7 9l3.5 3.5"/></symbol>
+  <symbol id="icon-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h9M17 6h3"/><circle cx="15" cy="6" r="2"/><path d="M4 12h3M11 12h9"/><circle cx="9" cy="12" r="2"/><path d="M4 18h9M17 18h3"/><circle cx="15" cy="18" r="2"/></symbol>
+  <symbol id="icon-help" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M9.5 9.5a2.5 2.5 0 1 1 3.5 2.3c-.8.4-1 .9-1 1.7"/><path d="M12 17h.01"/></symbol>
+  <symbol id="icon-plus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></symbol>
+  <symbol id="icon-minus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/></symbol>
+  <symbol id="icon-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6l12 12M18 6L6 18"/></symbol>
+  <symbol id="icon-pin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M12 21s-6.5-6.2-6.5-11a6.5 6.5 0 1 1 13 0c0 4.8-6.5 11-6.5 11z"/><circle cx="12" cy="10" r="2.4"/></symbol>
+  <symbol id="icon-command" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6a3 3 0 1 0-3 3h12a3 3 0 1 0-3-3v12a3 3 0 1 0 3-3H6a3 3 0 1 0 3 3z"/></symbol>
+  <symbol id="icon-camera" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M14.5 4h-5L7.5 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3z"/><circle cx="12" cy="13" r="3.2"/></symbol>
+  <symbol id="icon-history" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8A9 9 0 1 1 3 12"/><path d="M3 4v4h4"/><path d="M12 8v4l3 2"/></symbol>
+  <symbol id="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4 12H2M22 12h-2M5.6 5.6 4.2 4.2M19.8 19.8l-1.4-1.4M18.4 5.6l1.4-1.4M4.2 19.8l1.4-1.4"/></symbol>
+  <symbol id="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/></symbol>
+  <symbol id="icon-more" viewBox="0 0 24 24" fill="currentColor" stroke="none"><circle cx="5" cy="12" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="19" cy="12" r="1.6"/></symbol>
+  <symbol id="icon-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></symbol>
+  <symbol id="icon-copy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/></symbol>
+  <symbol id="icon-add-report" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4v7a4 4 0 0 0 4 4h6"/><path d="M11 12l3 3-3 3"/><path d="M18 4v6M15 7h6"/></symbol>
+  <symbol id="icon-move" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"/><path d="M8 7h9v9"/></symbol>
+  <symbol id="icon-focus" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="3.4"/><path d="M12 1.5v3M12 19.5v3M1.5 12h3M19.5 12h3"/></symbol>
+  <symbol id="icon-fit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3M21 8V5a2 2 0 0 0-2-2h-3M3 16v3a2 2 0 0 0 2 2h3M16 21h3a2 2 0 0 0 2-2v-3"/></symbol>
+  <symbol id="icon-trash" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/></symbol>
+  <symbol id="icon-compare" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="6" r="2.6"/><circle cx="19" cy="18" r="2.6"/><path d="M12 6h4a2 2 0 0 1 2 2v7"/><path d="M12 18H8a2 2 0 0 1-2-2V9"/></symbol>
+  <symbol id="icon-tag" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L3 13V3h10l7.6 7.6a2 2 0 0 1 0 2.8z"/><circle cx="8" cy="8" r="1.4"/></symbol>
+  <symbol id="icon-undo" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-1"/></symbol>
+  <symbol id="icon-redo" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M15 14l5-5-5-5"/><path d="M20 9H9a5 5 0 0 0 0 10h1"/></symbol>
+  <symbol id="icon-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></symbol>
+  <symbol id="icon-lock" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="11" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></symbol>
+</defs></svg>
+
+<!-- ========================= APP ========================= -->
+<div id="app">
+
+  <!-- ICON RAIL -->
+  <nav class="rail" aria-label="Primary">
+    <div class="rail-logo" title="Arbol Studio"><svg class="icon"><use href="#icon-tree"/></svg></div>
+    <button class="rail-btn active" aria-label="Charts" aria-current="page" title="Charts"><svg class="icon"><use href="#icon-charts"/></svg></button>
+    <button class="rail-btn" aria-label="People and search" title="People"><svg class="icon"><use href="#icon-search"/></svg></button>
+    <button class="rail-btn" aria-label="Analytics" title="Analytics"><svg class="icon"><use href="#icon-analytics"/></svg></button>
+    <button class="rail-btn" aria-label="Import and export" title="Import / Export"><svg class="icon"><use href="#icon-transfer"/></svg></button>
+    <button class="rail-btn" aria-label="Settings" title="Settings"><svg class="icon"><use href="#icon-settings"/></svg></button>
+    <div class="rail-spacer"></div>
+    <button class="rail-btn" aria-label="Help" title="Help"><svg class="icon"><use href="#icon-help"/></svg></button>
+  </nav>
+
+  <!-- HEADER -->
+  <header class="header">
+    <div class="crumb">
+      <span class="crumb-name">Acme Corp</span>
+      <svg class="icon crumb-sep" style="width:14px;height:14px"><use href="#icon-chevron"/></svg>
+      <span class="crumb-name" style="font-weight:600;color:var(--text-secondary)">Org · main</span>
+    </div>
+    <span class="save-state"><span class="save-dot"></span>All changes saved</span>
+
+    <div class="hdr-tools">
+      <button class="icon-btn" aria-label="Undo"><svg class="icon"><use href="#icon-undo"/></svg></button>
+      <button class="icon-btn" aria-label="Redo"><svg class="icon"><use href="#icon-redo"/></svg></button>
+      <span class="divider-v"></span>
+      <button class="cmd-btn" id="cmd-btn" aria-haspopup="dialog">
+        <svg class="icon"><use href="#icon-command"/></svg>
+        <span>Run a command</span>
+        <span class="kbd">⌘K</span>
+      </button>
+      <span class="divider-v"></span>
+      <button class="icon-btn" id="theme-toggle" aria-label="Switch to light theme" aria-pressed="false"><svg class="icon"><use href="#icon-sun"/></svg></button>
+      <button class="icon-btn" aria-label="Help and shortcuts"><svg class="icon"><use href="#icon-help"/></svg></button>
+    </div>
+  </header>
+
+  <!-- CHARTS PANEL -->
+  <aside class="panel" aria-label="Charts">
+    <div class="panel-head">
+      <span class="eyebrow">Charts</span>
+      <button class="panel-add" aria-label="New chart"><svg class="icon" style="width:15px;height:15px"><use href="#icon-plus"/></svg></button>
+    </div>
+    <div class="panel-search"><svg class="icon"><use href="#icon-search"/></svg><span>Search charts…</span></div>
+
+    <div class="chart-list">
+      <div class="chart-row active">
+        <span class="chart-ico"><svg class="icon" style="width:17px;height:17px"><use href="#icon-tree"/></svg></span>
+        <div class="chart-meta">
+          <div class="chart-nm">Acme Corp · Org</div>
+          <div class="chart-sub">13 people · 4 versions</div>
+        </div>
+        <div class="row-actions">
+          <button class="mini" aria-label="Rename chart"><svg class="icon"><use href="#icon-edit"/></svg></button>
+          <button class="mini" aria-label="Duplicate chart"><svg class="icon"><use href="#icon-copy"/></svg></button>
+          <button class="mini" aria-label="More options"><svg class="icon"><use href="#icon-more"/></svg></button>
+        </div>
+      </div>
+      <div class="chart-row">
+        <span class="chart-ico"><svg class="icon" style="width:17px;height:17px"><use href="#icon-tree"/></svg></span>
+        <div class="chart-meta">
+          <div class="chart-nm">2026 Reorg Plan</div>
+          <div class="chart-sub">15 people · 2 versions</div>
+        </div>
+        <div class="row-actions">
+          <button class="mini" aria-label="Rename chart"><svg class="icon"><use href="#icon-edit"/></svg></button>
+          <button class="mini" aria-label="Duplicate chart"><svg class="icon"><use href="#icon-copy"/></svg></button>
+          <button class="mini" aria-label="More options"><svg class="icon"><use href="#icon-more"/></svg></button>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel-section">
+      <span class="eyebrow" style="display:block;margin-bottom:10px">Categories</span>
+      <div class="legend-row"><span class="legend-dot" style="background:var(--cat-open)"></span>Open position<span class="legend-count num">1</span></div>
+      <div class="legend-row"><span class="legend-dot" style="background:var(--cat-offer)"></span>Offer pending<span class="legend-count num">1</span></div>
+      <div class="legend-row"><span class="legend-dot" style="background:var(--text-tertiary)"></span>Filled<span class="legend-count num">11</span></div>
+    </div>
+  </aside>
+
+  <!-- CANVAS -->
+  <section class="canvas" aria-label="Org chart canvas">
+    <div class="canvas-grid"></div>
+
+    <!-- compare banner -->
+    <div class="compare-flag" role="status">
+      <svg class="icon" style="width:15px;height:15px;color:var(--amber)"><use href="#icon-compare"/></svg>
+      <span class="cf-swatch"><span class="cf-a"></span><b>Pre-reorg Q2</b></span>
+      <svg class="icon cf-arrow" style="width:14px;height:14px"><use href="#icon-chevron"/></svg>
+      <span class="cf-swatch"><span class="cf-b"></span><b>Current</b></span>
+    </div>
+
+    <div class="stage">
+      <svg class="org-svg" viewBox="0 0 1954 430" role="img" aria-label="Organization chart, 13 people, Marcus Johnson selected">
+
+        <!-- base edges -->
+        <g id="base-edges">
+          <path class="edge" d="M1059,80 L1059,106 L493,106 L493,132"/>
+          <path class="edge" d="M1059,80 L1059,106 L1624,106 L1624,132"/>
+          <path class="edge" d="M493,188 L493,214 L222,214 L222,240"/>
+          <path class="edge" d="M493,188 L493,214 L764,214 L764,240"/>
+          <path class="edge" d="M222,296 L222,322 L120,322 L120,348"/>
+          <path class="edge" d="M222,296 L222,322 L324,322 L324,348"/>
+          <path class="edge" d="M764,296 L764,322 L560,322 L560,348"/>
+          <path class="edge" d="M764,296 L764,348"/>
+          <path class="edge" d="M764,296 L764,322 L968,322 L968,348"/>
+          <path class="edge" d="M1624,188 L1624,214 L1420,214 L1420,240"/>
+          <path class="edge" d="M1624,188 L1624,240"/>
+          <path class="edge" d="M1624,188 L1624,214 L1828,214 L1828,240"/>
+        </g>
+
+        <!-- nodes -->
+        <g id="base-nodes">
+          <!-- Sarah -->
+          <g class="node" transform="translate(965,24)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">SC</text>
+            <text class="nm" x="47" y="24">Sarah Chen</text><text class="ti" x="47" y="41">Chief Executive Officer</text>
+            <rect class="lvl" x="150" y="9" width="34" height="16" rx="8"/><text class="lvl-t" x="167" y="20">E12</text>
+          </g>
+          <!-- Marcus (selected) -->
+          <g class="node selected" id="node-marcus" transform="translate(399,132)" tabindex="0" role="button" aria-label="Marcus Johnson, VP Engineering, selected. Open inspector.">
+            <rect class="sel-ring" x="-4" y="-4" width="196" height="64" rx="14"/>
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">MJ</text>
+            <text class="nm" x="47" y="24">Marcus Johnson</text><text class="ti" x="47" y="41">VP Engineering</text>
+            <rect class="lvl" x="150" y="9" width="34" height="16" rx="8"/><text class="lvl-t" x="167" y="20">E10</text>
+          </g>
+          <!-- Priya -->
+          <g class="node" transform="translate(1530,132)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">PP</text>
+            <text class="nm" x="47" y="24">Priya Patel</text><text class="ti" x="47" y="41">VP Product</text>
+            <rect class="lvl" x="150" y="9" width="34" height="16" rx="8"/><text class="lvl-t" x="167" y="20">E10</text>
+          </g>
+          <!-- David -->
+          <g class="node" transform="translate(128,240)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">DK</text>
+            <text class="nm" x="47" y="24">David Kim</text><text class="ti" x="47" y="41">Sr. Engineering Manager</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">E8</text>
+          </g>
+          <!-- Lisa -->
+          <g class="node" transform="translate(670,240)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">LW</text>
+            <text class="nm" x="47" y="24">Lisa Wang</text><text class="ti" x="47" y="41">Engineering Manager</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">E8</text>
+          </g>
+          <!-- Nina -->
+          <g class="node" transform="translate(1326,240)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">NP</text>
+            <text class="nm" x="47" y="24">Nina Petrov</text><text class="ti" x="47" y="41">Sr. Product Manager</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">E8</text>
+          </g>
+          <!-- Carlos -->
+          <g class="node" transform="translate(1530,240)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">CR</text>
+            <text class="nm" x="47" y="24">Carlos Ruiz</text><text class="ti" x="47" y="41">Product Manager</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L6</text>
+          </g>
+          <!-- Yuki (offer pending) -->
+          <g class="node" transform="translate(1734,240)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">YT</text>
+            <text class="nm" x="47" y="24">Yuki Tanaka</text><text class="ti" x="47" y="41">Product Designer</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L6</text>
+            <circle class="cat cat-offer" cx="174" cy="44" r="4.5"/>
+          </g>
+          <!-- Tom -->
+          <g class="node" transform="translate(26,348)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">TR</text>
+            <text class="nm" x="47" y="24">Tom Rodriguez</text><text class="ti" x="47" y="41">Staff Engineer</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L7</text>
+          </g>
+          <!-- Ana -->
+          <g class="node" transform="translate(230,348)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">AC</text>
+            <text class="nm" x="47" y="24">Ana Costa</text><text class="ti" x="47" y="41">Senior Engineer</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L6</text>
+          </g>
+          <!-- James -->
+          <g class="node chg" transform="translate(466,348)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">JM</text>
+            <text class="nm" x="47" y="24">James Miller</text><text class="ti" x="47" y="41">Senior Engineer</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L6</text>
+          </g>
+          <!-- Emma -->
+          <g class="node chg" transform="translate(670,348)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">EW</text>
+            <text class="nm" x="47" y="24">Emma Wilson</text><text class="ti" x="47" y="41">Engineer</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L5</text>
+          </g>
+          <!-- Raj (open position) -->
+          <g class="node chg" transform="translate(874,348)">
+            <rect class="card" width="188" height="56" rx="11"/>
+            <circle class="mono-bg" cx="25" cy="28" r="13.5"/><text class="mono-t" x="25" y="31.5">RS</text>
+            <text class="nm" x="47" y="24">Raj Sharma</text><text class="ti" x="47" y="41">Engineer</text>
+            <rect class="lvl" x="152" y="9" width="32" height="16" rx="8"/><text class="lvl-t" x="168" y="20">L5</text>
+            <circle class="cat cat-open" cx="174" cy="44" r="4.5"/>
+          </g>
+        </g>
+
+        <!-- ===== DIFF OVERLAY (compare mode) ===== -->
+        <g class="diff-only" aria-hidden="true">
+          <!-- recolored / new edges -->
+          <path class="edge-move"   d="M764,296 L764,322 L560,322 L560,348"/>
+          <path class="edge-add"    d="M764,296 L764,348"/>
+          <path class="edge-add"    d="M764,296 L764,322 L968,322 L968,348"/>
+          <path class="edge-remove" d="M764,296 L764,322 L1200,322 L1200,348"/>
+
+          <!-- removed ghost: Kevin Brooks -->
+          <g class="ghost" transform="translate(1106,348)">
+            <rect class="g-card" width="188" height="56" rx="11"/>
+            <text class="g-nm" x="18" y="27">Kevin Brooks</text>
+            <text class="g-ti" x="18" y="43">Engineer · removed</text>
+            <circle class="dbadge-rem" cx="170" cy="15" r="9"/>
+            <path class="dbadge-g" d="M165.5,15 h9"/>
+          </g>
+
+          <!-- moved marker on James -->
+          <rect class="ring-move" x="462" y="344" width="196" height="64" rx="14"/>
+          <circle class="dbadge-move" cx="634" cy="356" r="9"/>
+          <path class="dbadge-g" d="M630.5,356 h7 M635,353.5 l2.5,2.5 -2.5,2.5"/>
+
+          <!-- added markers: Emma + Raj -->
+          <rect class="ring-add" x="666" y="344" width="196" height="64" rx="14"/>
+          <circle class="dbadge-add" cx="838" cy="356" r="9"/>
+          <path class="dbadge-g" d="M838,352.5 v7 M834.5,356 h7"/>
+
+          <rect class="ring-add" x="870" y="344" width="196" height="64" rx="14"/>
+          <circle class="dbadge-add" cx="1042" cy="356" r="9"/>
+          <path class="dbadge-g" d="M1042,352.5 v7 M1038.5,356 h7"/>
+        </g>
+      </svg>
+    </div>
+
+    <!-- floating toolbar -->
+    <div class="canvas-tools" role="toolbar" aria-label="Canvas controls">
+      <button class="ctool" aria-label="Zoom out"><svg class="icon"><use href="#icon-minus"/></svg></button>
+      <span class="zoom-val num">100%</span>
+      <button class="ctool" aria-label="Zoom in"><svg class="icon"><use href="#icon-plus"/></svg></button>
+      <span class="ctool-sep"></span>
+      <button class="ctool" aria-label="Fit to screen"><svg class="icon"><use href="#icon-fit"/></svg></button>
+      <button class="ctool" aria-label="Focus mode"><svg class="icon"><use href="#icon-focus"/></svg></button>
+    </div>
+
+    <!-- INSPECTOR -->
+    <aside class="inspector" id="inspector" aria-label="Person details">
+      <div class="insp-top">
+        <div class="insp-mono">MJ</div>
+        <div class="insp-id">
+          <div class="insp-name">Marcus Johnson</div>
+          <div class="insp-title">VP Engineering</div>
+        </div>
+        <button class="insp-close" id="inspector-close" aria-label="Close inspector"><svg class="icon"><use href="#icon-x"/></svg></button>
+      </div>
+
+      <div class="insp-body">
+        <div class="mapped">
+          <svg class="icon"><use href="#icon-tag"/></svg>
+          <div class="mapped-txt">
+            <div class="mapped-lbl">Mapped title</div>
+            <div class="mapped-val">VP, Engineering</div>
+          </div>
+          <span class="pin"><svg class="icon"><use href="#icon-pin"/></svg>Pinned</span>
+        </div>
+
+        <div class="insp-grid">
+          <div class="stat"><div class="stat-v">2</div><div class="stat-l">Direct reports</div></div>
+          <div class="stat"><div class="stat-v">7</div><div class="stat-l">Total org</div></div>
+          <div class="stat"><div class="stat-v">2.3</div><div class="stat-l">Avg span</div></div>
+        </div>
+
+        <div class="field">
+          <span class="eyebrow">Level</span>
+          <div class="level-line">
+            <span class="level-pill">E10</span>
+            <span class="level-band"><span class="level-fill"></span></span>
+            <span class="num" style="font-size:11px;color:var(--text-tertiary)">10 / 12</span>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="eyebrow">Category</span>
+          <div class="chips">
+            <span class="chip sel">None</span>
+            <span class="chip"><span class="dot" style="background:var(--cat-open)"></span>Open position</span>
+            <span class="chip"><span class="dot" style="background:var(--cat-offer)"></span>Offer pending</span>
+          </div>
+        </div>
+
+        <div class="field" style="margin-bottom:4px">
+          <span class="eyebrow">Reports to</span>
+          <div class="level-line" style="margin-top:6px">
+            <span class="insp-mono" style="width:26px;height:26px;font-size:10px;border-radius:7px">SC</span>
+            <span style="font-size:13px;font-weight:600">Sarah Chen</span>
+            <span style="font-size:11px;color:var(--text-tertiary);margin-left:auto">CEO · E12</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="insp-actions">
+        <button class="btn-primary"><svg class="icon"><use href="#icon-add-report"/></svg>Add report</button>
+        <div class="action-row">
+          <button class="btn-ghost"><svg class="icon"><use href="#icon-move"/></svg>Move</button>
+          <button class="btn-ghost"><svg class="icon"><use href="#icon-focus"/></svg>Focus</button>
+          <button class="btn-ghost"><svg class="icon"><use href="#icon-lock"/></svg>Dotted line</button>
+          <button class="btn-ghost danger"><svg class="icon"><use href="#icon-trash"/></svg>Remove</button>
+        </div>
+      </div>
+    </aside>
+  </section>
+
+  <!-- TIMELINE (SIGNATURE) -->
+  <section class="timeline" aria-label="Version timeline">
+    <div class="tl-head">
+      <span class="eyebrow"><svg class="icon"><use href="#icon-history"/></svg>Version history</span>
+      <span class="tl-sub"><b>4</b> versions · current is live</span>
+    </div>
+
+    <div class="tl-track">
+      <div class="tl-axis"></div>
+      <div class="tl-range"></div>
+
+      <button class="snap" style="left:5%">
+        <span class="snap-lbl">Founding</span><span class="snap-dot"></span>
+      </button>
+      <button class="snap pick-a" style="left:31%">
+        <span class="snap-lbl">Pre-reorg Q2</span><span class="snap-dot"></span><span class="snap-ab">A</span>
+      </button>
+      <button class="snap" style="left:50%">
+        <span class="snap-lbl">Post-reorg</span><span class="snap-dot"></span>
+      </button>
+      <button class="snap" style="left:69%">
+        <span class="snap-lbl">Headcount plan</span><span class="snap-dot"></span>
+      </button>
+      <div class="work pick-b" style="left:94%">
+        <span class="work-lbl">Current</span><span class="work-dot"></span><span class="snap-ab">B</span>
+      </div>
+
+      <div class="tl-months">
+        <span>Jan</span><span>Feb</span><span>Mar</span><span>Apr</span><span>May</span><span>Jun</span><span>Jul</span>
+      </div>
+    </div>
+
+    <div class="tl-actions">
+      <button class="btn-compare" id="compare-toggle"><svg class="icon"><use href="#icon-compare"/></svg>Compare</button>
+      <div class="diff-chips" role="group" aria-label="Diff summary">
+        <span class="dchip add"><span class="d"></span>+2 added</span>
+        <span class="dchip move"><span class="d"></span>1 moved</span>
+        <span class="dchip rem"><span class="d"></span>1 removed</span>
+        <button class="exit-btn" id="compare-exit"><svg class="icon"><use href="#icon-x"/></svg>Exit</button>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTNOTE -->
+  <footer class="footnote">
+    <svg class="icon"><use href="#icon-lock"/></svg>
+    <span>Local-first — your org never leaves this device.</span>
+    <span style="color:var(--border-strong)">•</span>
+    <span>Static mock. <b>Live:</b> theme toggle, command palette (⌘K), inspector, and compare mode. Editing, import/export and settings are presentational.</span>
+    <span class="foot-ver">Arbol Studio 4.0</span>
+  </footer>
+</div>
+
+<!-- ========================= COMMAND PALETTE ========================= -->
+<div class="palette-scrim" id="palette" role="dialog" aria-modal="true" aria-label="Command palette">
+  <div class="palette" role="document">
+    <div class="pal-input-wrap">
+      <svg class="icon"><use href="#icon-search"/></svg>
+      <input id="palette-input" type="text" placeholder="Type a command or search people…" autocomplete="off" spellcheck="false" aria-label="Command search">
+      <button class="pal-esc" id="palette-close">Esc</button>
+    </div>
+    <div class="pal-body" id="pal-body">
+      <div class="pal-group" data-group>
+        <div class="pal-group-lbl eyebrow">Recently used</div>
+        <button class="pal-item" data-text="save a version"><span class="pal-ico"><svg class="icon"><use href="#icon-camera"/></svg></span><span class="pal-label">Save a version</span><span class="pal-hint"><span class="kbd">⌘S</span></span></button>
+        <button class="pal-item" data-text="compare pre-reorg q2 current"><span class="pal-ico"><svg class="icon"><use href="#icon-compare"/></svg></span><span class="pal-label">Compare with “Pre-reorg Q2”</span><span class="pal-hint"><span class="kbd">⌘⇧C</span></span></button>
+        <button class="pal-item" data-text="add report marcus johnson"><span class="pal-ico"><svg class="icon"><use href="#icon-add-report"/></svg></span><span class="pal-label">Add report to Marcus Johnson</span><span class="pal-hint"><span class="kbd">⌘↵</span></span></button>
+      </div>
+      <div class="pal-group" data-group>
+        <div class="pal-group-lbl eyebrow">Actions</div>
+        <button class="pal-item" data-text="find person title search"><span class="pal-ico"><svg class="icon"><use href="#icon-search"/></svg></span><span class="pal-label">Find person or title</span><span class="pal-hint"><span class="kbd">⌘P</span></span></button>
+        <button class="pal-item" data-text="recolor by category"><span class="pal-ico"><svg class="icon"><use href="#icon-tag"/></svg></span><span class="pal-label">Recolor by category</span><span class="pal-hint"><span class="kbd">⌘⇧K</span></span></button>
+        <button class="pal-item" data-text="import from csv"><span class="pal-ico"><svg class="icon"><use href="#icon-transfer"/></svg></span><span class="pal-label">Import from CSV</span><span class="pal-hint"><span class="kbd">⌘I</span></span></button>
+        <button class="pal-item" data-text="export as png image"><span class="pal-ico"><svg class="icon"><use href="#icon-transfer"/></svg></span><span class="pal-label">Export as PNG</span><span class="pal-hint"><span class="kbd">⌘E</span></span></button>
+        <button class="pal-item" data-text="toggle focus mode"><span class="pal-ico"><svg class="icon"><use href="#icon-focus"/></svg></span><span class="pal-label">Toggle focus mode</span><span class="pal-hint"><span class="kbd">F</span></span></button>
+        <button class="pal-item" data-text="open settings preferences"><span class="pal-ico"><svg class="icon"><use href="#icon-settings"/></svg></span><span class="pal-label">Open settings</span><span class="pal-hint"><span class="kbd">⌘,</span></span></button>
+        <button class="pal-item" data-text="switch light dark theme appearance"><span class="pal-ico"><svg class="icon"><use href="#icon-moon"/></svg></span><span class="pal-label">Switch theme</span><span class="pal-hint"><span class="kbd">⌘⇧L</span></span></button>
+      </div>
+      <div class="pal-empty" id="pal-empty">No commands match your search.</div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var app = document.getElementById('app');
+
+  /* ---- theme toggle ---- */
+  var themeBtn = document.getElementById('theme-toggle');
+  themeBtn.addEventListener('click', function () {
+    var light = app.getAttribute('data-theme') === 'light';
+    if (light) { app.removeAttribute('data-theme'); }
+    else { app.setAttribute('data-theme', 'light'); }
+    var nowLight = !light;
+    themeBtn.setAttribute('aria-pressed', String(nowLight));
+    themeBtn.setAttribute('aria-label', nowLight ? 'Switch to dark theme' : 'Switch to light theme');
+    themeBtn.querySelector('use').setAttribute('href', nowLight ? '#icon-moon' : '#icon-sun');
+  });
+
+  /* ---- inspector open / close ---- */
+  var inspector = document.getElementById('inspector');
+  var node = document.getElementById('node-marcus');
+  document.getElementById('inspector-close').addEventListener('click', function () {
+    inspector.classList.add('hidden');
+    node.focus();
+  });
+  function openInspector() { inspector.classList.remove('hidden'); }
+  node.addEventListener('click', openInspector);
+  node.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openInspector(); }
+  });
+
+  /* ---- compare mode ---- */
+  document.getElementById('compare-toggle').addEventListener('click', function () {
+    app.classList.add('comparing');
+    document.getElementById('compare-exit').focus();
+  });
+  document.getElementById('compare-exit').addEventListener('click', function () {
+    app.classList.remove('comparing');
+    document.getElementById('compare-toggle').focus();
+  });
+
+  /* ---- command palette ---- */
+  var palette = document.getElementById('palette');
+  var input = document.getElementById('palette-input');
+  var items = Array.prototype.slice.call(palette.querySelectorAll('.pal-item'));
+  var groups = Array.prototype.slice.call(palette.querySelectorAll('[data-group]'));
+  var empty = document.getElementById('pal-empty');
+
+  function openPalette() {
+    palette.classList.add('open');
+    input.value = '';
+    filter('');
+    setTimeout(function () { input.focus(); }, 20);
+  }
+  function closePalette() { palette.classList.remove('open'); }
+
+  function filter(q) {
+    q = q.trim().toLowerCase();
+    var anyVisible = false;
+    items.forEach(function (it) {
+      var match = !q || it.getAttribute('data-text').indexOf(q) !== -1 ||
+                  it.querySelector('.pal-label').textContent.toLowerCase().indexOf(q) !== -1;
+      it.style.display = match ? '' : 'none';
+      it.classList.remove('cur');
+      if (match) anyVisible = true;
+    });
+    groups.forEach(function (g) {
+      var vis = g.querySelectorAll('.pal-item:not([style*="none"])').length;
+      g.style.display = vis ? '' : 'none';
+    });
+    empty.style.display = anyVisible ? 'none' : 'block';
+    var first = items.filter(function (i) { return i.style.display !== 'none'; })[0];
+    if (first) first.classList.add('cur');
+  }
+
+  document.getElementById('cmd-btn').addEventListener('click', openPalette);
+  document.getElementById('palette-close').addEventListener('click', closePalette);
+  palette.addEventListener('click', function (e) { if (e.target === palette) closePalette(); });
+  input.addEventListener('input', function () { filter(input.value); });
+
+  document.addEventListener('keydown', function (e) {
+    var mod = e.metaKey || e.ctrlKey;
+    if (mod && (e.key === 'k' || e.key === 'K')) {
+      e.preventDefault();
+      palette.classList.contains('open') ? closePalette() : openPalette();
+    } else if (e.key === 'Escape' && palette.classList.contains('open')) {
+      closePalette();
+    }
+  });
+
+  /* keyboard nav within palette */
+  input.addEventListener('keydown', function (e) {
+    var vis = items.filter(function (i) { return i.style.display !== 'none'; });
+    var idx = vis.findIndex(function (i) { return i.classList.contains('cur'); });
+    if (e.key === 'ArrowDown') { e.preventDefault(); move(vis, idx, 1); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); move(vis, idx, -1); }
+    else if (e.key === 'Enter') { e.preventDefault(); if (vis[idx]) closePalette(); }
+  });
+  function move(vis, idx, dir) {
+    if (!vis.length) return;
+    if (idx >= 0) vis[idx].classList.remove('cur');
+    var next = (idx + dir + vis.length) % vis.length;
+    vis[next].classList.add('cur');
+    vis[next].scrollIntoView({ block: 'nearest' });
+  }
+})();
+</script>
+</body>
+</html>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -875,9 +875,7 @@ const en: Record<string, string> = {
   'welcome.description': 'Build and explore your org chart, entirely in your browser.',
   'welcome.import_hint': 'Already have org data? Use Import in the toolbar to bring it in.',
   'welcome.load_sample': 'Load sample org chart',
-  'welcome.load_sample_aria': 'Load the sample organization chart',
   'welcome.start_empty': 'Start empty',
-  'welcome.start_empty_aria': 'Start with an empty organization chart',
 
   // Help: Getting Started
   'help.getting_started.title': 'Getting Started',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -870,6 +870,15 @@ const en: Record<string, string> = {
     'This will replace the current chart with a sample organization. You can undo this action.',
   'help.section_toggle_aria': 'Toggle {section} section',
 
+  // ─── First-run welcome ─────────────────────────────────────────────
+  'welcome.title': 'Welcome to Arbol',
+  'welcome.description': 'Build and explore your org chart, entirely in your browser.',
+  'welcome.import_hint': 'Already have org data? Use Import in the toolbar to bring it in.',
+  'welcome.load_sample': 'Load sample org chart',
+  'welcome.load_sample_aria': 'Load the sample organization chart',
+  'welcome.start_empty': 'Start empty',
+  'welcome.start_empty_aria': 'Start with an empty organization chart',
+
   // Help: Getting Started
   'help.getting_started.title': 'Getting Started',
   'help.getting_started.pan_zoom':

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -833,9 +833,7 @@ const es: Record<string, string> = {
   'welcome.description': 'Cree y explore su organigrama, directamente en su navegador.',
   'welcome.import_hint': '¿Ya tiene datos? Use Importar en la barra de herramientas.',
   'welcome.load_sample': 'Cargar organigrama de ejemplo',
-  'welcome.load_sample_aria': 'Cargar el organigrama de ejemplo',
   'welcome.start_empty': 'Empezar vacío',
-  'welcome.start_empty_aria': 'Empezar con un organigrama vacío',
 
   // Help: Getting Started
   'help.getting_started.title': 'Primeros pasos',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -828,6 +828,15 @@ const es: Record<string, string> = {
     'Esto reemplazará el organigrama actual con una organización de ejemplo. Puede deshacer esta acción.',
   'help.section_toggle_aria': 'Alternar sección {section}',
 
+  // ─── Bienvenida inicial ────────────────────────────────────────────
+  'welcome.title': 'Le damos la bienvenida a Arbol',
+  'welcome.description': 'Cree y explore su organigrama, directamente en su navegador.',
+  'welcome.import_hint': '¿Ya tiene datos? Use Importar en la barra de herramientas.',
+  'welcome.load_sample': 'Cargar organigrama de ejemplo',
+  'welcome.load_sample_aria': 'Cargar el organigrama de ejemplo',
+  'welcome.start_empty': 'Empezar vacío',
+  'welcome.start_empty_aria': 'Empezar con un organigrama vacío',
+
   // Help: Getting Started
   'help.getting_started.title': 'Primeros pasos',
   'help.getting_started.pan_zoom':

--- a/src/init/first-visit-helper.ts
+++ b/src/init/first-visit-helper.ts
@@ -1,5 +1,5 @@
-import { HELP_SECTION_IDS, showHelpDialog } from '../ui/help-dialog';
 import { type IStorage, browserStorage } from '../utils/storage';
+import { showWelcomeDialog } from '../ui/welcome-dialog';
 
 const WELCOME_KEY = 'arbol-welcome-seen';
 
@@ -9,10 +9,7 @@ export function showFirstVisitHelp(
 ): boolean {
   if (storage.getItem(WELCOME_KEY)) return false;
 
-  showHelpDialog({
-    initialSection: HELP_SECTION_IDS.gettingStarted,
-    onLoadSample,
-  });
+  showWelcomeDialog(onLoadSample);
   storage.setItem(WELCOME_KEY, 'true');
   return true;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -686,6 +686,52 @@ g.pal-node:focus-visible > rect {
   animation: slideUp 200ms ease;
 }
 
+.welcome-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  text-align: center;
+}
+
+.welcome-dialog-mark {
+  display: flex;
+  justify-content: center;
+  color: var(--accent);
+  font-size: var(--text-2xl);
+}
+
+.welcome-dialog-title {
+  color: var(--text-primary);
+  font-size: var(--text-xl);
+}
+
+.welcome-dialog-description,
+.welcome-dialog-import-hint {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
+.welcome-dialog-import-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+}
+
+.welcome-dialog-actions {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.welcome-dialog-actions .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  margin: 0;
+}
+
 .help-dialog {
   background: var(--bg-surface);
   padding: 0;

--- a/src/ui/import-wizard-steps.ts
+++ b/src/ui/import-wizard-steps.ts
@@ -190,18 +190,22 @@ export function renderMappingStep(
 
     // Auto-match saved presets against CSV headers
     const matchedPreset = findMatchingPreset(state.headers, presets ?? []);
+    const initialMapping = matchedPreset?.mapping ?? findCommonHeaderMapping(state.headers);
     if (matchedPreset) {
       state.mapping = matchedPreset.mapping;
-      state.matchedPresetName = matchedPreset.name;
+      state.matchedPresetName = matchedPreset.preset.name;
       const msg = document.createElement('p');
       msg.className = 'wizard-success';
-      msg.textContent = t('import_wizard.preset_matched', { name: matchedPreset.name });
+      msg.textContent = t('import_wizard.preset_matched', { name: matchedPreset.preset.name });
       container.appendChild(msg);
+    } else if (initialMapping) {
+      state.mapping = initialMapping;
+      state.matchedPresetName = undefined;
     }
 
     const desc = document.createElement('p');
     desc.className = 'wizard-info';
-    desc.textContent = matchedPreset
+    desc.textContent = initialMapping
       ? t('import_wizard.mapping_verify')
       : t('import_wizard.mapping_csv');
     container.appendChild(desc);
@@ -224,9 +228,9 @@ export function renderMappingStep(
       () => {},
     );
 
-    // Pre-fill dropdowns if preset matched
-    if (matchedPreset) {
-      mapper.prefill(matchedPreset.mapping);
+    // Pre-fill dropdowns when headers match a preset or common field names
+    if (initialMapping) {
+      mapper.prefill(initialMapping);
       mapper.handleApply();
     }
 
@@ -241,22 +245,71 @@ export function renderMappingStep(
       radio.addEventListener('change', () => mapper.handleApply());
     });
 
-    onReady(!!matchedPreset);
+    onReady(!!initialMapping);
   }
+}
+
+const NAME_HEADER_ALIASES = new Set(['name', 'full name', 'employee', 'employee name']);
+const TITLE_HEADER_ALIASES = new Set(['title', 'role', 'position', 'job title']);
+const MANAGER_HEADER_ALIASES = new Set(['manager', 'manager name', 'reports to', 'supervisor']);
+const NO_HEADER_ALIASES = new Set<string>();
+
+function normalizeHeaderName(value: string): string {
+  return value.trim().toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ');
+}
+
+function findHeader(
+  headers: string[],
+  configuredName: string,
+  aliases: ReadonlySet<string>,
+): string | undefined {
+  const normalizedConfiguredName = normalizeHeaderName(configuredName);
+  const exactMatch = headers.find(
+    (header) => normalizeHeaderName(header) === normalizedConfiguredName,
+  );
+  if (exactMatch) return exactMatch;
+  if (!aliases.has(normalizedConfiguredName)) return undefined;
+  return headers.find((header) => aliases.has(normalizeHeaderName(header)));
+}
+
+function findCommonHeaderMapping(headers: string[]): ColumnMapping | undefined {
+  const name = headers.find((header) => NAME_HEADER_ALIASES.has(normalizeHeaderName(header)));
+  const title = headers.find((header) => TITLE_HEADER_ALIASES.has(normalizeHeaderName(header)));
+  const parentRef = headers.find((header) =>
+    MANAGER_HEADER_ALIASES.has(normalizeHeaderName(header)),
+  );
+  if (!name || !title || !parentRef) return undefined;
+
+  return {
+    name,
+    title,
+    parentRef,
+    parentRefType: 'name',
+    caseInsensitive: true,
+  };
+}
+
+interface MatchedPreset {
+  preset: MappingPreset;
+  mapping: ColumnMapping;
 }
 
 function findMatchingPreset(
   headers: string[],
   presets: MappingPreset[],
-): MappingPreset | undefined {
-  const headerSet = new Set(headers.map((h) => h.toLowerCase()));
+): MatchedPreset | undefined {
   for (const preset of presets) {
     const m = preset.mapping;
-    const cols = [m.name, m.title, m.parentRef];
-    if (m.id) cols.push(m.id);
-    if (cols.every((col) => headerSet.has(col.toLowerCase()))) {
-      return preset;
-    }
+    const name = findHeader(headers, m.name, NAME_HEADER_ALIASES);
+    const title = findHeader(headers, m.title, TITLE_HEADER_ALIASES);
+    const parentRef = findHeader(headers, m.parentRef, MANAGER_HEADER_ALIASES);
+    const id = m.id ? findHeader(headers, m.id, NO_HEADER_ALIASES) : undefined;
+    if (!name || !title || !parentRef || (m.id && !id)) continue;
+
+    return {
+      preset,
+      mapping: { ...m, name, title, parentRef, id },
+    };
   }
   return undefined;
 }

--- a/src/ui/welcome-dialog.ts
+++ b/src/ui/welcome-dialog.ts
@@ -36,14 +36,12 @@ export function showWelcomeDialog(onLoadSample: () => void): void {
   const sampleButton = document.createElement('button');
   sampleButton.type = 'button';
   sampleButton.className = 'btn btn-primary';
-  sampleButton.setAttribute('aria-label', t('welcome.load_sample_aria'));
   appendIconLabel(sampleButton, 'tree', t('welcome.load_sample'));
   actions.appendChild(sampleButton);
 
   const emptyButton = document.createElement('button');
   emptyButton.type = 'button';
   emptyButton.className = 'btn btn-secondary';
-  emptyButton.setAttribute('aria-label', t('welcome.start_empty_aria'));
   appendIconLabel(emptyButton, 'add', t('welcome.start_empty'));
   actions.appendChild(emptyButton);
 

--- a/src/ui/welcome-dialog.ts
+++ b/src/ui/welcome-dialog.ts
@@ -1,0 +1,74 @@
+import { t } from '../i18n';
+import { activateDialog, createDialogPanel, createOverlay } from './dialog-utils';
+import { appendIconLabel, createIcon } from './icon';
+
+export function showWelcomeDialog(onLoadSample: () => void): void {
+  const previouslyFocused = document.activeElement;
+  const overlay = createOverlay();
+  const dialog = createDialogPanel({ ariaLabelledBy: 'welcome-dialog-title' });
+  dialog.classList.add('welcome-dialog');
+
+  const mark = document.createElement('div');
+  mark.className = 'welcome-dialog-mark';
+  mark.appendChild(createIcon('tree'));
+  dialog.appendChild(mark);
+
+  const title = document.createElement('h2');
+  title.id = 'welcome-dialog-title';
+  title.className = 'welcome-dialog-title';
+  title.textContent = t('welcome.title');
+  dialog.appendChild(title);
+
+  const description = document.createElement('p');
+  description.className = 'welcome-dialog-description';
+  description.textContent = t('welcome.description');
+  dialog.appendChild(description);
+
+  const importHint = document.createElement('p');
+  importHint.className = 'welcome-dialog-import-hint';
+  importHint.appendChild(createIcon('import'));
+  importHint.appendChild(document.createTextNode(t('welcome.import_hint')));
+  dialog.appendChild(importHint);
+
+  const actions = document.createElement('div');
+  actions.className = 'welcome-dialog-actions';
+
+  const sampleButton = document.createElement('button');
+  sampleButton.type = 'button';
+  sampleButton.className = 'btn btn-primary';
+  sampleButton.setAttribute('aria-label', t('welcome.load_sample_aria'));
+  appendIconLabel(sampleButton, 'tree', t('welcome.load_sample'));
+  actions.appendChild(sampleButton);
+
+  const emptyButton = document.createElement('button');
+  emptyButton.type = 'button';
+  emptyButton.className = 'btn btn-secondary';
+  emptyButton.setAttribute('aria-label', t('welcome.start_empty_aria'));
+  appendIconLabel(emptyButton, 'add', t('welcome.start_empty'));
+  actions.appendChild(emptyButton);
+
+  dialog.appendChild(actions);
+  overlay.appendChild(dialog);
+  document.body.appendChild(overlay);
+
+  let deactivate = () => {};
+  const close = () => {
+    deactivate();
+    overlay.remove();
+  };
+
+  deactivate = activateDialog(dialog, {
+    onEscape: close,
+    restoreFocusTo: previouslyFocused,
+  });
+
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) close();
+  });
+  sampleButton.addEventListener('click', () => {
+    onLoadSample();
+    close();
+  });
+  emptyButton.addEventListener('click', close);
+  sampleButton.focus();
+}

--- a/tests/init/first-visit-helper.test.ts
+++ b/tests/init/first-visit-helper.test.ts
@@ -21,6 +21,10 @@ function makeStorage(): IStorage & {
   };
 }
 
+function accessibleName(element: HTMLElement): string {
+  return (element.getAttribute('aria-label') ?? element.textContent ?? '').trim();
+}
+
 describe('showFirstVisitHelp', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
@@ -50,6 +54,20 @@ describe('showFirstVisitHelp', () => {
     expect(dialogs[0].textContent).toContain('Start empty');
     expect(dialogs[0].textContent).toContain('Import');
   });
+
+  it.each(['Load sample org chart', 'Start empty'])(
+    'uses the visible label "%s" as the button accessible name',
+    (visibleLabel) => {
+      const storage = makeStorage();
+      showFirstVisitHelp(vi.fn(), storage);
+
+      const button = Array.from(document.querySelectorAll('button')).find(
+        (candidate) => candidate.textContent?.trim() === visibleLabel,
+      );
+      expect(button).toBeDefined();
+      expect(accessibleName(button!)).toBe(visibleLabel);
+    },
+  );
 
   it('sets storage flag after showing help', () => {
     const storage = makeStorage();

--- a/tests/init/first-visit-helper.test.ts
+++ b/tests/init/first-visit-helper.test.ts
@@ -27,16 +27,28 @@ describe('showFirstVisitHelp', () => {
   });
 
   afterEach(() => {
+    let dialog = document.querySelector('[role="dialog"], [role="alertdialog"]');
+    while (dialog) {
+      document.body.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }),
+      );
+      dialog = document.querySelector('[role="dialog"], [role="alertdialog"]');
+    }
     document.body.innerHTML = '';
   });
 
-  it('shows help dialog on first visit and returns true', () => {
+  it('shows one welcome dialog with sample, empty, and Import choices on first visit', () => {
     const storage = makeStorage();
     const onLoadSample = vi.fn();
     const result = showFirstVisitHelp(onLoadSample, storage);
 
     expect(result).toBe(true);
-    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+    const dialogs = document.querySelectorAll('[role="dialog"], [role="alertdialog"]');
+    expect(dialogs).toHaveLength(1);
+    expect(dialogs[0].textContent).toContain('Welcome to Arbol');
+    expect(dialogs[0].textContent).toContain('Load sample org chart');
+    expect(dialogs[0].textContent).toContain('Start empty');
+    expect(dialogs[0].textContent).toContain('Import');
   });
 
   it('sets storage flag after showing help', () => {
@@ -56,22 +68,33 @@ describe('showFirstVisitHelp', () => {
     expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 
-  it('opens the Getting Started section on first visit', () => {
-    const storage = makeStorage();
-    showFirstVisitHelp(vi.fn(), storage);
-
-    const openSectionHeader = document.querySelector('.help-section.open .help-section-header');
-    expect(openSectionHeader?.textContent).toContain('Getting Started');
-  });
-
-  it('passes onLoadSample to help dialog', () => {
+  it('loads the sample immediately and closes the welcome dialog without stacking a prompt', () => {
     const storage = makeStorage();
     const onLoadSample = vi.fn();
     showFirstVisitHelp(onLoadSample, storage);
 
-    const sampleBtn = Array.from(document.querySelectorAll('button')).find((b) =>
-      b.textContent?.includes('Load Sample Org Chart'),
+    const sampleButton = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Load sample org chart'),
     );
-    expect(sampleBtn).toBeDefined();
+    expect(sampleButton).toBeDefined();
+    sampleButton!.click();
+
+    expect(onLoadSample).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll('[role="dialog"], [role="alertdialog"]')).toHaveLength(0);
+  });
+
+  it('starts empty without loading a sample and closes the welcome dialog', () => {
+    const storage = makeStorage();
+    const onLoadSample = vi.fn();
+    showFirstVisitHelp(onLoadSample, storage);
+
+    const emptyButton = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Start empty'),
+    );
+    expect(emptyButton).toBeDefined();
+    emptyButton!.click();
+
+    expect(onLoadSample).not.toHaveBeenCalled();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
   });
 });

--- a/tests/ui/import-wizard-steps.test.ts
+++ b/tests/ui/import-wizard-steps.test.ts
@@ -179,12 +179,12 @@ describe('renderMappingStep', () => {
     expect(state.format).toBe('CSV');
   });
 
-  it('shows CSV description for CSV data', () => {
+  it('asks users to verify an automatically mapped CSV', () => {
     const state: WizardState = { rawText: 'name,title,manager_name\nAlice,CEO,\n' };
     renderMappingStep(container, state, vi.fn());
     const desc = container.querySelector('.wizard-info');
     expect(desc).not.toBeNull();
-    expect(desc!.textContent).toContain('Map your CSV columns');
+    expect(desc!.textContent).toContain('Verify the column mapping');
   });
 
   it('extracts headers from CSV and stores in state', () => {
@@ -193,11 +193,77 @@ describe('renderMappingStep', () => {
     expect(state.headers).toEqual(['name', 'title', 'manager_name']);
   });
 
-  it('calls onReady(false) initially for CSV', () => {
+  it('auto-maps the standard CSV headers and calls onReady(true)', () => {
     const state: WizardState = { rawText: 'name,title,manager_name\nAlice,CEO,\n' };
     const onReady = vi.fn();
     renderMappingStep(container, state, onReady);
-    expect(onReady).toHaveBeenCalledWith(false);
+    expect(state.mapping).toMatchObject({
+      name: 'name',
+      title: 'title',
+      parentRef: 'manager_name',
+      parentRefType: 'name',
+    });
+    expect(onReady).toHaveBeenCalledWith(true);
+  });
+
+  it.each([
+    ['Full Name', 'Job Title', 'Reports To'],
+    ['Employee', 'Role', 'Supervisor'],
+    ['Employee Name', 'Position', 'Manager Name'],
+    ['Name', 'Title', 'Manager'],
+  ])('auto-maps representative headers: %s, %s, %s', (name, title, manager) => {
+    const state: WizardState = {
+      rawText: `${name},${title},${manager}\nAlice,CEO,\n`,
+    };
+
+    renderMappingStep(container, state, vi.fn());
+
+    expect(state.mapping).toMatchObject({
+      name,
+      title,
+      parentRef: manager,
+      parentRefType: 'name',
+    });
+  });
+
+  it('matches header synonyms without regard to case or repeated whitespace', () => {
+    const state: WizardState = {
+      rawText: '  FULL   NAME  , job TITLE , MANAGER   NAME \nAlice,CEO,\n',
+    };
+
+    renderMappingStep(container, state, vi.fn());
+
+    expect(state.mapping).toMatchObject({
+      name: 'FULL   NAME',
+      title: 'job TITLE',
+      parentRef: 'MANAGER   NAME',
+    });
+  });
+
+  it('matches a saved mapping preset through semantic header synonyms', () => {
+    const state: WizardState = {
+      rawText: 'Full Name,Job Title,Reports To\nAlice,CEO,\n',
+    };
+    const presets = [
+      {
+        name: 'Standard columns',
+        mapping: {
+          name: 'name',
+          title: 'title',
+          parentRef: 'manager',
+          parentRefType: 'name' as const,
+        },
+      },
+    ];
+
+    renderMappingStep(container, state, vi.fn(), presets);
+
+    expect(state.matchedPresetName).toBe('Standard columns');
+    expect(state.mapping).toMatchObject({
+      name: 'Full Name',
+      title: 'Job Title',
+      parentRef: 'Reports To',
+    });
   });
 
   it('clears container before rendering', () => {


### PR DESCRIPTION
## M8b — Docs, onboarding & Direction B preservation (final milestone)

- **README** refreshed to the post-redesign reality (icons, tokens, dialogs, settings groups, inspector-first editing, version vocabulary)
- **First-run**: single welcome dialog (Load sample / Start empty / import hint) replacing stacked prompts
- **Import wizard**: header auto-mapping now matches common synonyms (full name, role, reports to, supervisor, …)
- **docs/design/future-directions.md** + both interactive mocks committed — Direction B ("Arbol Studio") preserved as future inspiration, with the owner decision noted that chart rendering/presets/layout are final as-is

Part of the Refined Arbol roadmap (M8b). Sentinel review to follow; will rebase over M9 if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)